### PR TITLE
Update Gemfile to try and resolve broken dependancies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'jekyll-toc'
 gem 'json'
 gem 'rouge'
 gem 'jekyll-octicons'
+gem "ffi", "< 1.17.0"  # to fix broken depedancies as per https://github.com/ffi/ffi/issues/1103
 
 group :jekyll_plugins do
   gem 'jekyll-mentions'


### PR DESCRIPTION
I'm trying to resolve an error that appears when a recent merge triggered a netlify deploy that failed. The merge code seems fine and was submitted after a discussion on #316.

I think the root of the problem is something to do with rubygems. I haven't build with this tool previously. I found [this potential fix](https://github.com/ffi/ffi/issues/1103) after searching around a little. I'm not 100% confident it's correct so I hope someone can help review the fix and confirm it's safe to try