### PR TITLE
Fix netlify.toml: deploy-preview builds silently fell back to running jekyll algolia

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,7 @@
 # Deploy Preview context:
 # All deploys generated from a pull/merge request
 # will inherit these settings.
-[context.deploy-preview.environment]
+[context.deploy-preview]
   command = "jekyll build"
 
 # Branch deploy context:


### PR DESCRIPTION
## Summary
- `[context.deploy-preview.environment]` declares environment *variables* for that context, not a build command override — so the `command = "jekyll build"` line under it was never actually applied as the deploy-preview build command.
- Because the override silently failed, PR/preview builds fell back to the site-wide UI build command (`... && jekyll build && jekyll algolia`), which runs `jekyll algolia` on every preview.
- That fails on any PR build with **"Missing API key"**, because Netlify correctly withholds the secret `ALGOLIA_API_KEY` from deploy-preview contexts — this is intentional secret scoping, not an expired/invalid key.
- Fix: change the table header to `[context.deploy-preview]` so the command override actually takes effect, matching the already-correct `[context.branch-deploy]` block below it. Preview builds go back to just `jekyll build`; only production deploys (which legitimately have the secret) run `jekyll algolia`.

## Test plan
- [ ] Confirm a new PR build against this branch succeeds without the "Missing API key" error
- [ ] Confirm a production (main branch) deploy still runs `jekyll algolia` successfully and updates the Algolia index

🤖 Generated with [Claude Code](https://claude.com/claude-code)