### PR TITLE
Remove domain-squatted/hijacked links from 5 lab entries

### DIFF
--- a/_labs/BioFoundry/BioFoundry.md
+++ b/_labs/BioFoundry/BioFoundry.md
@@ -1,7 +1,6 @@
 ---
 title: Bio Foundry
 subtitle: Australia's first community lab for citizen scientists
-website: http://foundry.bio/
 start-date: 2014
 type-org: non-profit
 address: 296 Botany Road
@@ -12,7 +11,6 @@ country: Australia
 _geoloc:
   lat: -33.904579
   lng: 151.202014
-rss: http://foundry.bio/feed/
 facebook: https://www.facebook.com/thebiofoundry/
 ---
 

--- a/_labs/BiologiGaragen/BiologiGaragen.md
+++ b/_labs/BiologiGaragen/BiologiGaragen.md
@@ -2,7 +2,6 @@
 title: BiologiGaragen
 tags:
 - hackerspace
-website: http://biologigaragen.org/
 start-date: 2010
 hosts: "[Labitat](https://labitat.dk/)"
 type-org: community
@@ -13,8 +12,6 @@ country: Denmark
 _geoloc:
   lat: 55.676540
   lng: 12.545520
-blog: http://biologigaragen.org/blog/
-rss: http://biologigaragen.org/feed
 twitter: https://twitter.com/biologigaragen
 facebook: https://www.facebook.com/groups/biologigaragen/
 vimeo: https://vimeo.com/biologigaragen

--- a/_labs/HiveBio/HiveBio.md
+++ b/_labs/HiveBio/HiveBio.md
@@ -1,6 +1,5 @@
 ---
 title: HiveBio
-website: http://hivebio.org/
 start-date: 2013
 type-org: community
 address: 4000 NE 41st St.

--- a/_labs/LaPaillase/LaPaillase.md
+++ b/_labs/LaPaillase/LaPaillase.md
@@ -1,6 +1,5 @@
 ---
 title: La Paillase
-website: http://lapaillasse.org/
 start-date: 2011
 type-org: non-profit
 partners:

--- a/_labs/LifePatch/LifePatch.md
+++ b/_labs/LifePatch/LifePatch.md
@@ -10,7 +10,6 @@ country: Indonesia
 _geoloc:
   lat: -7.795758
   lng: 110.377080
-wiki: http://lifepatch.org/
 ---
 
 is a community-based cross-disciplinary organization formed on March 26, 2012. On the initiative of citizens in art, science and technology, Lifepatch invites Members and anyone involved in its activities to research, explore, and develop the presence of technology, natural resources, and human resources in the surrounding area. Citizen initiatives are chosen to provide a wider space for the diversity of member practices and spur the creativity of each member in a role in a collaborative activity. Do It Yourself (DIY) and Do It With Others (DIWO) is the passion that Lifepatch holds in practice in order to spur the emergence of new patterns and systems straightforwardly from individual and community creative processes, as well as interaction between individuals in the community work series.


### PR DESCRIPTION
## Summary
Part of a broader audit of the Labs collection's current web/social presence (64 entries checked). 5 entries have a stored URL that no longer points to the organization at all — the domain has lapsed and been picked up by something unrelated:

| Lab | Field(s) removed | What's there now |
|---|---|---|
| HiveBio | `website` | Online lottery/gambling page |
| Bio Foundry | `website`, `rss` | Online gambling site (org deregistered Feb 2023) |
| La Paillasse | `website` | Gun-scope retailer |
| LifePatch | `wiki` | Spam/adult-content site (real org is alive at lifepatch.id) |
| BiologiGaragen | `website`, `blog`, `rss` | GoDaddy "domain for sale" parking page |

Only the compromised URL fields are removed — front matter (address, social links that are still fine, tags, etc.) and the entry body text are untouched, so these stay in the directory as a historical record rather than being deleted outright.

## Test plan
- [ ] Confirm each entry's page still renders correctly with the field removed (no broken template reference to `website`/`blog`/`rss`/`wiki`)
- [ ] Confirm none of the 5 pages show a dead link where the removed field used to be linked

🤖 Generated with [Claude Code](https://claude.com/claude-code)