### PR TITLE
Fix broken BUGSS promo image path on homepage carousel

### DIFF
--- a/_labs/Bugss/Bugss.md
+++ b/_labs/Bugss/Bugss.md
@@ -37,7 +37,7 @@ promotions:
   - button:  More info about BUGSS
     text: BUGSS is Baltimore's community science lab, offering seminars, courses, and an open lab space for both amateurs and professionals.
     URL: https://bugssonline.org/
-    image: /labs/buggs/promo.png
+    image: /labs/bugss/promo.png
 ---
 
 BUGSS is a non-profit public laboratory offering classes, seminars, and lab access so that anyone can safely and affordably investigate the living world. We are a community of amateurs, professionals, citizen


### PR DESCRIPTION
## Summary
- The homepage carousel was rendering squished/overlapping slides. Root cause: BUGSS's `promotions[0].image` front-matter field pointed to `/labs/buggs/promo.png` (typo — extra "g"), which 404s. The real file is at `/labs/bugss/promo.png`, matching the entry's actual URL slug.
- The broken `<img>` throws off Owl Carousel's slide-width calculation, which cascades into the layout problem across neighboring slides.
- One-line fix: correct the path.

## Test plan
- [ ] Load the homepage on the deploy preview and confirm the carousel renders cleanly with no squished/overlapping slides
- [ ] Confirm the BUGSS slide itself shows its promo image correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)