### PR TITLE
Update Labs status field from live-web audit (64 entries)

### DIFF
--- a/_labs/ArtScienceBlr/ArtScienceBlr.md
+++ b/_labs/ArtScienceBlr/ArtScienceBlr.md
@@ -1,5 +1,6 @@
 ---
 title: Art Science BLR
+status: unknown
 tags:
 - bioart
 subtitle: Public Laboratory at the Srishi Intitute of Art, Design & Technology

--- a/_labs/BioArtLaboratories/BioArtLaboratories.md
+++ b/_labs/BioArtLaboratories/BioArtLaboratories.md
@@ -1,5 +1,6 @@
 ---
 title: Bio Art Laboratores
+status: active
 tags:
 - bioart
 website: http://bioartlab.com/

--- a/_labs/BioBlaze/BioBlaze.md
+++ b/_labs/BioBlaze/BioBlaze.md
@@ -1,5 +1,6 @@
 ---
 title: BioBlaze Community Bio Lab
+status: unknown
 subtitle: The first community bio lab in Chicagoland
 website: https://www.bioblaze.org/
 start-date: 2017-10

--- a/_labs/BioClubTokyo/BioClubTokyo.md
+++ b/_labs/BioClubTokyo/BioClubTokyo.md
@@ -1,5 +1,6 @@
 ---
 title: BioClub Tokyo Community Bio Lab
+status: active
 subtitle: The community bio lab in Tokyo
 website: https://www.bioclub.tokyo
 start-date: 2015

--- a/_labs/BioCrea/biocrea.md
+++ b/_labs/BioCrea/biocrea.md
@@ -1,5 +1,6 @@
 ---
 title: BioCrea:Espacio Abierto de Biología Creativa
+status: unknown
 subtitle: #REPLACE_with_a_short_description,_or_motto._Max_250_characters
 website: https://www.medialab-prado.es/programas/biocrea-espacio-abierto-de-biologia-creativa #REPLACE_with_the_main_URL_for_initiative
 start-date: 2018 #REPLACE_with_the_start_date._MUST_FORMAT_as:_'YYYY'_or_'YYYY-MM'_or_'YYYY-MM-DD'

--- a/_labs/BioDidact/BioDidact.md
+++ b/_labs/BioDidact/BioDidact.md
@@ -1,5 +1,6 @@
 ---
 title: Biodidact
+status: unknown
 website: http://biodidact.net/
 start-date: 2014
 type-org: community

--- a/_labs/BioFoundry/BioFoundry.md
+++ b/_labs/BioFoundry/BioFoundry.md
@@ -1,5 +1,6 @@
 ---
 title: Bio Foundry
+status: inactive
 subtitle: Australia's first community lab for citizen scientists
 start-date: 2014
 type-org: non-profit

--- a/_labs/BioHackPhilly/BioHackPhilly.md
+++ b/_labs/BioHackPhilly/BioHackPhilly.md
@@ -1,6 +1,7 @@
 ---
 draft: true
 title: BioHackPhilly
+status: unknown
 subtitle: Synthetic Biology is the future of food, fuel, materials, and medicine. And we are here to teach you the basics.
 start-date: 2020
 hosts:

--- a/_labs/BioLabsLisboa/BioLabsLisboa.md
+++ b/_labs/BioLabsLisboa/BioLabsLisboa.md
@@ -1,6 +1,7 @@
 ---
 draft: true
 title: BioLab Lisboa
+status: active
 subtitle: Lisbon citizens Lab
 start-date: 2022-01-13
 hosts:

--- a/_labs/BioMakersLabPeru/BioMakersLabPeru.md
+++ b/_labs/BioMakersLabPeru/BioMakersLabPeru.md
@@ -1,5 +1,6 @@
 ---
 title: Biomakers Lab Peru
+status: unknown
 subtitle:
 website: http://biomakerslab.wixsite.com/
 start-date: 2014

--- a/_labs/BioNyfiken/BioNyfiken.md
+++ b/_labs/BioNyfiken/BioNyfiken.md
@@ -1,5 +1,6 @@
 ---
 title: BioNyfiken
+status: inactive
 website: http://www.bionyfiken.se/
 start-date: 2014
 type-org: non-profit

--- a/_labs/BioQuisitive/BioQuisitive.md
+++ b/_labs/BioQuisitive/BioQuisitive.md
@@ -1,5 +1,6 @@
 ---
 title: BuiQuisitive
+status: active
 alias: Melbourn BioHack
 website: http://bioquisitive.org.au/
 start-date: 2015

--- a/_labs/BioTehna/BioTehna.md
+++ b/_labs/BioTehna/BioTehna.md
@@ -1,5 +1,6 @@
 ---
 title: BioTehna
+status: active
 website:
 start-date: 2013
 address: Litijska cesta 259

--- a/_labs/Biocurious/Biocurious.md
+++ b/_labs/Biocurious/Biocurious.md
@@ -1,5 +1,6 @@
 ---
 title: Biocurious
+status: active
 tags:
 - open source
 - synthetic biology

--- a/_labs/BiohackUIO/BiohackUIO.md
+++ b/_labs/BiohackUIO/BiohackUIO.md
@@ -9,7 +9,7 @@ type-org: community
 # ACTIVITY
 start-date: 2020
 end-date:
-status:
+status: active
 
 # RELATIONSHIPS
 partners:

--- a/_labs/BiologiGaragen/BiologiGaragen.md
+++ b/_labs/BiologiGaragen/BiologiGaragen.md
@@ -1,5 +1,6 @@
 ---
 title: BiologiGaragen
+status: inactive
 tags:
 - hackerspace
 start-date: 2010

--- a/_labs/BiologikLabs/BiologikLabs.md
+++ b/_labs/BiologikLabs/BiologikLabs.md
@@ -1,5 +1,6 @@
 ---
 title: Biologik Labs
+status: unknown
 website: http://www.biologiklabs.org/
 start-date: 2013
 type-org: community

--- a/_labs/Bionest/Bionest.md
+++ b/_labs/Bionest/Bionest.md
@@ -1,5 +1,6 @@
 ---
 title: Bionest
+status: active
 subtitle: Biohacker Space by Agrobioteg
 website: http://agrobioteg.org/
 start-date: 2018-06

--- a/_labs/Bioscope/Bioscope.md
+++ b/_labs/Bioscope/Bioscope.md
@@ -1,5 +1,6 @@
 ---
 title: Bioscope
+status: active
 website: http://bioscope.ch/
 start-date: 2014
 hosts: University of Geneva

--- a/_labs/BiotechWithoutBorders/BiotechWithoutBorders.md
+++ b/_labs/BiotechWithoutBorders/BiotechWithoutBorders.md
@@ -1,5 +1,6 @@
 ---
 title: Biotech Without Borders
+status: unknown
 subtitle: NYC's Member-led Community Biolab
 website: https://biotechwithoutborders.org
 header: https://biotechwithoutborders.org/wp-content/uploads/2022/05/7bcb702c-8374-4495-92ba-d40d86ba38b1.jpg

--- a/_labs/BosLab/BosLab.md
+++ b/_labs/BosLab/BosLab.md
@@ -1,5 +1,6 @@
 ---
 title: BosLab
+status: active
 website: http://boslab.org/
 start-date: 2014
 type-org: non-profit

--- a/_labs/BricoBio/BricoBio.md
+++ b/_labs/BricoBio/BricoBio.md
@@ -1,6 +1,7 @@
 ---
 draft: true
 title: Bricobio
+status: unknown
 subtitle: biotech for everyone
 start-date: 2013
 hosts:

--- a/_labs/BrmBiolab/BrmBiolab.md
+++ b/_labs/BrmBiolab/BrmBiolab.md
@@ -1,5 +1,6 @@
 ---
 title: Brmlab
+status: active
 website: http://brmlab.cz/index.html
 start-date:
 type-org: non-profit

--- a/_labs/Bugss/Bugss.md
+++ b/_labs/Bugss/Bugss.md
@@ -1,6 +1,7 @@
 ---
 draft: true
 title: Baltimore Underground Science Space (BUGSS)
+status: active
 subtitle: A place for creative biology
 start-date: 2012
 hosts:

--- a/_labs/CapitalAreaBioSpace/CapitalAreaBioSpace.md
+++ b/_labs/CapitalAreaBioSpace/CapitalAreaBioSpace.md
@@ -1,5 +1,6 @@
 ---
 title: Capital Area BioSpace
+status: unknown
 website: https://www.meetup.com/CapitalAreaBioSpace/
 start-date:
 hosts: "[Nova Labs](http://www.nova-labs.org/blog/)"

--- a/_labs/ChiTownBio/ChiTownBio.md
+++ b/_labs/ChiTownBio/ChiTownBio.md
@@ -1,6 +1,7 @@
 ---
 draft: true
 title: ChiTownBio
+status: active
 subtitle: Chicago's first community biolab
 start-date: 2017
 hosts:

--- a/_labs/CounterCultureLabs/CounterCultureLabs.md
+++ b/_labs/CounterCultureLabs/CounterCultureLabs.md
@@ -1,5 +1,6 @@
 ---
 title: Counter Culture Labs
+status: active
 subtitle: Your Biohacking and Citizen Science Lab in Oakland
 website: http://counterculturelabs.org/
 start-date: 2013

--- a/_labs/DIYBioBCN/DIYBioBCN.md
+++ b/_labs/DIYBioBCN/DIYBioBCN.md
@@ -1,5 +1,6 @@
 ---
 title: DIY Bio Barcelona
+status: unknown
 website: http://www.diybcn.org/
 start-date: 2014
 hosts: "[MADE](http://made-bcn.org/)"

--- a/_labs/DIYBioTech/DIYBioTech.md
+++ b/_labs/DIYBioTech/DIYBioTech.md
@@ -1,5 +1,6 @@
 ---
 title: DIYbioTech
+status: inactive
 tags:
 - makerspace
 start-date: 2013

--- a/_labs/DIYbioToronto/DIYbioToronto.md
+++ b/_labs/DIYbioToronto/DIYbioToronto.md
@@ -1,6 +1,7 @@
 ---
 draft: true
 title: DIYbio Toronto
+status: active
 subtitle: Toronto's Bio-Enthusiast group. Everyone's welcome!
 start-date: 2013
 hosts:

--- a/_labs/DenverBiolabs/DenverBiolabs.md
+++ b/_labs/DenverBiolabs/DenverBiolabs.md
@@ -1,5 +1,6 @@
 ---
 title: Denver Biolabs
+status: inactive
 website: http://denverbiolabs.com/
 start-date: 2015
 type-org: non-profit

--- a/_labs/FLab/FLab.md
+++ b/_labs/FLab/FLab.md
@@ -1,5 +1,6 @@
 ---
 title: F.lab
+status: unknown
 website: http://f-lab.cc/
 start-date:
 type-org: community

--- a/_labs/FormaLabs/FormaLabs.md
+++ b/_labs/FormaLabs/FormaLabs.md
@@ -1,5 +1,6 @@
 ---
 title: Forma Labs
+status: inactive
 subtitle:
 website: http://formalabs.org/
 start-date: 2014

--- a/_labs/GaroaOpenBiolab/GaroaOpenBiolab.md
+++ b/_labs/GaroaOpenBiolab/GaroaOpenBiolab.md
@@ -4,7 +4,7 @@ tags:
   - hackerspace
 website: https://garoa.net.br/wiki/Garoa_Open_BioLab
 start-date: 2011
-status: planning
+status: unknown
 hosts: "[Garao Hacker Clube](https://garoa.net.br/wiki/P%C3%A1gina_principal)"
 type-org: community
 address: R. Costa Carvalho, 567 - Pinheiros

--- a/_labs/GaudiLabs/GaudiLabs.md
+++ b/_labs/GaudiLabs/GaudiLabs.md
@@ -1,5 +1,6 @@
 ---
 title: GaudiLabs
+status: active
 website: http://www.gaudi.ch/GaudiLabs/
 start-date:
 type-org: non-profit

--- a/_labs/Hackuarium/Hackuarium.md
+++ b/_labs/Hackuarium/Hackuarium.md
@@ -1,5 +1,6 @@
 ---
 title: Hackuarium
+status: active
 subtitle: An Open Laboratory for DIY Biology (And Beyond)
 website: http://www.hackuarium.ch/en/
 promotions:

--- a/_labs/HiveBio/HiveBio.md
+++ b/_labs/HiveBio/HiveBio.md
@@ -1,5 +1,6 @@
 ---
 title: HiveBio
+status: inactive
 start-date: 2013
 type-org: community
 address: 4000 NE 41st St.

--- a/_labs/Incubatorartlab/INCUBATORartlab.md
+++ b/_labs/Incubatorartlab/INCUBATORartlab.md
@@ -1,6 +1,7 @@
 ---
 draft: true
 title: INCUBATOR art lab
+status: active
 subtitle: Hybrid Labratory at the Intersection of Art, Science and Ecology
 start-date: 2009
 hosts:

--- a/_labs/IndieLab/IndieLab.md
+++ b/_labs/IndieLab/IndieLab.md
@@ -1,5 +1,6 @@
 ---
 title: Indie Lab
+status: unknown
 website: http://rva.indielab.co/
 start-date: 2012
 hosts: "[Hack RVA](http://www.hackrva.org/blog/)"

--- a/_labs/JustOneGiantLab/JustOneGiantLab.md
+++ b/_labs/JustOneGiantLab/JustOneGiantLab.md
@@ -1,5 +1,6 @@
 ---
 title: Just One Giant Lab
+status: active
 subtitle: We help sync humanity onto solving our most urgent & important problems using Open Science, Responsible Innovation & Continuous Learning 
 website: http://jogl.io/
 start-date: 2015

--- a/_labs/Kaouenn-Noz/kaouenn-noz.md
+++ b/_labs/Kaouenn-Noz/kaouenn-noz.md
@@ -1,5 +1,6 @@
 ---
 title: Kaouenn-Noz
+status: active
 subtitle: A Biohackerspace in Brittany 
 type-org: community
 predecessor: Biome HackLab # the previous name of the entry

--- a/_labs/Katalab/Katalab.md
+++ b/_labs/Katalab/Katalab.md
@@ -1,5 +1,6 @@
 ---
 title: "[kat]alab Vienna"
+status: unknown
 subtitle: Initiative for Open Science, Technology, Art and Education
 type-org: community
 start-date: 2017

--- a/_labs/LEprouvette/LEprouvette.md
+++ b/_labs/LEprouvette/LEprouvette.md
@@ -1,5 +1,6 @@
 ---
 title: L'Eprouvette
+status: active
 logo: https://pbs.twimg.com/profile_images/535440714058838017/O1ezBMSc_400x400.jpeg
 website: http://wp.unil.ch/mediationscientifique/activites/eprouvette
 start-date: 2005

--- a/_labs/LaJollaBiolab/LaJollaBiolab.md
+++ b/_labs/LaJollaBiolab/LaJollaBiolab.md
@@ -1,5 +1,6 @@
 ---
 title: La Jolla Bio Lab
+status: unknown
 website: http://lajollalibrary.org/your-library/bio-lab/
 start-date: 2015
 type-org: public

--- a/_labs/LaPaillase/LaPaillase.md
+++ b/_labs/LaPaillase/LaPaillase.md
@@ -1,5 +1,6 @@
 ---
 title: La Paillase
+status: inactive
 start-date: 2011
 type-org: non-profit
 partners:

--- a/_labs/LaPaillaseSaone/LaPaillaseSaone.md
+++ b/_labs/LaPaillaseSaone/LaPaillaseSaone.md
@@ -1,5 +1,6 @@
 ---
 title: La Paillase Saône
+status: inactive
 website: https://lapaillassaone.wordpress.com/
 start-date: 2015
 hosts: '[La MYNE](https://www.lamyne.org/)'

--- a/_labs/LifePatch/LifePatch.md
+++ b/_labs/LifePatch/LifePatch.md
@@ -1,5 +1,6 @@
 ---
 title: LifePatch
+status: active
 subtitle: Citizen Initiative in Art, Science and Technology
 start-date:
 type-org: community

--- a/_labs/LondonBiohackerspace/LondonBiohackerspace.md
+++ b/_labs/LondonBiohackerspace/LondonBiohackerspace.md
@@ -1,5 +1,6 @@
 ---
 title: London Biohackspace
+status: inactive
 tags:
 - hackerspace
 website: https://biohackspace.org/

--- a/_labs/MadLabBiolab/MadLabBiolab.md
+++ b/_labs/MadLabBiolab/MadLabBiolab.md
@@ -1,5 +1,6 @@
 ---
 title: MadLab Biolab
+status: inactive
 website: https://madlab.org.uk/community-biotechnology/
 start-date:
 type-org: non-profit

--- a/_labs/OpenBioLabGraz/OpenBioLabGraz.md
+++ b/_labs/OpenBioLabGraz/OpenBioLabGraz.md
@@ -1,5 +1,6 @@
 ---
 title: Open bioLab Graz Austria
+status: active
 website: https://realraum.at/wiki/doku.php?id=olga:olga
 start-date: 2013
 hosts: "[Real Raum](https://realraum.at/wiki/doku.php?id=realraum)"

--- a/_labs/OpenBioLabs/OpenBioLabs.md
+++ b/_labs/OpenBioLabs/OpenBioLabs.md
@@ -1,5 +1,6 @@
 ---
 title: Charlottesville Open Bio Labs
+status: inactive
 logo: http://openbiolabs.org/wp-content/uploads/2015/04/COBL_web_logo.png
 website: http://openbiolabs.org/
 start-date: 2015

--- a/_labs/OpenScienceNet/OpenScienceNet.md
+++ b/_labs/OpenScienceNet/OpenScienceNet.md
@@ -1,5 +1,6 @@
 ---
 title: Open Science Network
+status: unknown
 tags:
   - makerspace
 website: http://www.opensciencenet.org/

--- a/_labs/OpenWetlab/OpenWetlab.md
+++ b/_labs/OpenWetlab/OpenWetlab.md
@@ -1,5 +1,6 @@
 ---
 title: Open Wetlab
+status: active
 website: https://waag.org/en/lab/open-wetlab
 start-date: 2012
 hosts: "[Waag Society](http://waag.org/en)"

--- a/_labs/OttawaBioScience/OttawaBioScience.md
+++ b/_labs/OttawaBioScience/OttawaBioScience.md
@@ -1,5 +1,6 @@
 ---
 title: Ottawa Bio Science
+status: active
 subtitle: Ottawa's DIY Biology Community
 website: http://specyal.com
 start-date: 2018

--- a/_labs/PechBlenda/PechBlenda.md
+++ b/_labs/PechBlenda/PechBlenda.md
@@ -1,5 +1,6 @@
 ---
 title: PechBlenda Lab
+status: unknown
 subtitle: Laboratory of bioelectrochemical experimentations
 website: https://pechblenda.hotglue.me/
 start-date:

--- a/_labs/Reagent/Reagent.md
+++ b/_labs/Reagent/Reagent.md
@@ -1,5 +1,6 @@
 ---
 title: ReaGent
+status: inactive
 website: http://reagentlab.org/
 start-date: 2015
 type-org: community

--- a/_labs/Scihouse/Scihouse.md
+++ b/_labs/Scihouse/Scihouse.md
@@ -2,7 +2,7 @@
 draft: true
 title: Scihouse
 subtitle: Moving biotechnology forward for the common good
-status: active
+status: unknown
 hosts:
   - DIYbiosphere
 type-org:

--- a/_labs/SoundBioLab/SoundBioLab.md
+++ b/_labs/SoundBioLab/SoundBioLab.md
@@ -1,5 +1,6 @@
 ---
 title: SoundBio Lab
+status: active
 subtitle: Seattle's Biology Makerspace
 website: https://sound.bio/
 start-date: 2016

--- a/_labs/Symbiolab/Symbiolab.md
+++ b/_labs/Symbiolab/Symbiolab.md
@@ -1,5 +1,6 @@
 ---
 title: Symbiolab
+status: inactive
 subtitle: Open and DIY biolaboratory
 website: http://irnas.eu/symbiolab.html
 start-date: 2014

--- a/_labs/TurbiniaBioLab/turbiniabiolab.md
+++ b/_labs/TurbiniaBioLab/turbiniabiolab.md
@@ -1,5 +1,6 @@
 ---
 title: Turbine Bio Lab
+status: unknown
 tags:
 - bioart
 - fermentation

--- a/_labs/top/top.md
+++ b/_labs/top/top.md
@@ -1,5 +1,6 @@
 ---
 title: top
+status: active
 subtitle: transdisciplinary project place for art and science in Berlin
 website: http://www.top-ev.de/
 start-date: 2017


### PR DESCRIPTION
## Summary
Follow-up to the Labs collection cleanup (#332, #333). We audited the live website and social media presence of all 64 entries in `_labs/` and are setting an explicit `status` on each one, so the site's status filter reflects reality rather than a date-math guess.

Why this matters: `_plugins/add-variables-to-files.rb` only auto-derives `status` when the field is absent, based purely on `start-date`/`end-date` — any entry with a past start date and no end date defaults to "active". Since almost none of these entries have ever had `end-date` filled in when a lab actually closed, that heuristic was wrong for a large share of the collection.

**Mapping used** (the audit produced 5 categories; the site's status vocabulary only has 3):
- **active (29)** — live site and/or recent (2024–2026) activity signal
- **inactive (15)** — confirmed closed, domain dead/squatted, or org dissolved
- **unknown (20)** — no reliable signal either way (merges the audit's Stale + Dormant + Unknown findings)

Two entries had an existing but stale explicit status corrected:
- `GaroaOpenBiolab`: `planning` → `unknown` (no visible update to the "planning" phase since 2020)
- `Scihouse`: `active` → `unknown` (site unreachable, no programming found since ~2019)

58 entries get a new `status` field; nothing else in any entry is touched.

## Test plan
- [ ] Confirm the Labs status facet counts on `/browse` update to roughly 29 active / 20 unknown / 15 inactive after deploy
- [ ] Spot check a few entries (e.g. HiveBio, GaudiLabs, Scihouse) render correctly with the new field

🤖 Generated with [Claude Code](https://claude.com/claude-code)