### PR TITLE
Remove dormant Slack references from the site and community docs

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -9,4 +9,4 @@ Follow steps of each type of issue
 - [ ] **report broken link** _title:_ 'Broken link'. _description:_ where you encountered the broken link
 - [ ] **report a bug** _description:_ describe the problem, how you encountered it and what you expected instead. Provide screenshots and screencaptures if possible
 - [ ] **make a suggestion** _description:_ describe your idea, how it should work and look like. Provide examples and references.
-- [ ] **ask a question** _title:_ include a '?'. Or ask questions in Slack, you can directly message users there. Check our FAQs too.
+- [ ] **ask a question** _title:_ include a '?'. Check our FAQs too.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ toc: true
 
 Thank you for considering contributing to DIYbiosphere! The project depends on the participation of the DIYbio community.
 
-There are many ways you can contribute, from adding and editing entries, writing tutorials, improving the documentation, submitting bug and broken link reports, feature requests or writing code to better the website. You _can_ submit questions as issues, but please consider first posing your question in [Slack](https://diybiosphere.slack.com), where you can also directly message other contributors.
+There are many ways you can contribute, from adding and editing entries, writing tutorials, improving the documentation, submitting bug and broken link reports, feature requests or writing code to better the website. You can submit questions as issues, or reach out to a member directly.
 
 # Ground Rules
 By contributing, you agree to abide to our [Code of Conduct](http://sphere.diybio.org/about/code-of-conduct) (COC) and consent to our [Contributor Terms](http://sphere.diybio.org/about/contributor-terms) (CT) set by our [Terms of Use](http://sphere.diybio.org/about/terms-of-use) (_aka_ Copyright).

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ In increasing order of engagement you can contribute to DIYbiosphere by:
   - **Fork, commit, pull request** your contributions! Tackle a [good first issue](https://github.com/DIYbiosphere/sphere/labels/good%20first%20issue) to get you started
 - **GETTING INVOLVED**
   - **Join the development community**. The project is managed by members of the [DIYbiosphere community](https://sphere.diybio.org/about/community). Request membership by [submitting an issue](https://github.com/DIYbiosphere/sphere/issues/new) enjoy more access privileges to the project!
-  - **Join the conversation**. You can freely join us in Slack at [diybiosphere.slack.com](https://diybiosphere.slack.com)
+  - **Join the conversation**. [Submit an issue](https://github.com/DIYbiosphere/sphere/issues/new) - that's where the majority of project conversations happen.
 
 ## Copyright
 In short: **the work in DIYbiosphere is freely available to use, modify and distribute.** More specifically:

--- a/_references.md
+++ b/_references.md
@@ -6,7 +6,6 @@
 [Biotech Without Borders]: /labs/biotechwithoutborders/
 [BwoB]: /labs/biotechwithoutborders/
 
-[slack]: https://diybiosphere.slack.com/ "DIYbiosphere Slack"
 [mit]: https://opensource.org/licenses/MIT "MIT License"
 [cc0]: https://creativecommons.org/publicdomain/zero/1.0/ "Creative Commons Zero License"
 [sign up]: https://github.com/join "Sign up to GitHub"

--- a/about/contact.md
+++ b/about/contact.md
@@ -9,8 +9,5 @@ As part of [our values] we strive to maintain our communication as public as pos
 We use GitHub's Issues to organize and manage the development of the project. The majority of conversations related to the project should happen here. The [Issues] are public, but in order to submit a new issue you need a GitHub account ([sign up](https://github.com/join)). You can submit a question, suggestion, or a [request to join][join] the DIYbiosphere organization.
 
 
-### Slack
-Is a very popular communication platform that offers integration with other services including GitHub notifications. We have our own Slack: [DIYbiosphere.slack.com][slack]. You can join any channel and specify your notification preferences. Post your message in a channel or DM other users.
-
 ### Twitter
 For the moment our Twitter account it is somewhat inactive during alpha release. Once we go to beta release we will set up some automatic tweets for every new entry added to the library.

--- a/about/faq.md
+++ b/about/faq.md
@@ -6,4 +6,4 @@ layout: page
 **No one has asked questions so far...**
 
 
-> Have a question that is not answered here? Ask us by submitting a [new issue] in our repo, or through our [Slack] channels.
+> Have a question that is not answered here? Ask us by submitting a [new issue] in our repo.

--- a/about/support-us.md
+++ b/about/support-us.md
@@ -15,7 +15,7 @@ Interested in helping our project? There are several ways you can support us!
 
 #### Get involved with the development
 - **Become a developer** Become a member of the [development community]. [Request membership][join] and enjoy greater permission levels.
-- **Join the conversation** Contact a member to request an invite to our Slack at [diybiosphere.slack.com][slack].
+- **Join the conversation** Submit an [issue][new issue] - that's where the majority of project conversations happen.
 
 #### Provide some funding for the project
 - **Donate to DIYbio.org through [PayPal](https://www.paypal.com/us/cgi-bin/webscr?cmd=_flow&SESSION=QHyIMzotHrQMm0QnVeiBIRChwwWJ1VwScC1xt-q477yQzO4uFKTPQ-WFyra&dispatch=5885d80a13c0db1f8e263663d3faee8d94717bd303200c3af9aadd01a5f55080)** Make sure to specify "DIYbiosphere" in the _purpose_ comment box.

--- a/docs/guides/glossary.md
+++ b/docs/guides/glossary.md
@@ -30,8 +30,6 @@ toc: true
 
 **Pull request** or **PR**
 
-**Slack**
-
 **Ticket**
 
 **Version Control** a way to track changes to a document or collection of documents.


### PR DESCRIPTION
## Summary
Follow-up to #337 — DIYbiosphere's Slack is also dormant, not just Gitter. Removed every mention of it as a contact/community channel (README, CONTRIBUTING, FAQ, Contact Us, Support Us, GitHub issue template), the empty "Slack" glossary stub, and the now-unused `[slack]` reference-link definition. GitHub Issues — already documented in Contact Us as where "the majority of conversations related to the project should happen" — is the channel pointed to throughout now.

**Left untouched:** the generic per-entry `slack:` front-matter support (`_includes/entry/links-icons.html`, `docs/guides/writing.md`, `assets/data/dataset.yml`) and Denver Biolabs' own `slack:` field — unrelated infrastructure/data for individual lab entries with their own Slack workspace.

## Test plan
- [ ] Confirm Contact Us, FAQ, and Support Us pages render cleanly with no dangling references
- [ ] Confirm the README-derived docs overview page reads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)