### PR TITLE
Finish removing Biotech Without Borders' broken carousel image

### DIFF
--- a/_labs/BiotechWithoutBorders/BiotechWithoutBorders.md
+++ b/_labs/BiotechWithoutBorders/BiotechWithoutBorders.md
@@ -3,7 +3,6 @@ title: Biotech Without Borders
 status: active
 subtitle: NYC's Member-led Community Biolab
 website: https://biotechwithoutborders.org
-header: https://biotechwithoutborders.org/wp-content/uploads/2022/05/7bcb702c-8374-4495-92ba-d40d86ba38b1.jpg
 start-date: 2017
 type-org: non-profit
 address: 43-01 21ST Street, Suite 319


### PR DESCRIPTION
## Summary
Follow-up to #336, which removed `promotions[].image` from Biotech Without Borders but missed that the carousel template falls back to `entry.header` when `promotion.image` is absent (`index.html`: `{% if promotion.image or entry.header %}` ... `<img ... src="{{ entry.header }}">`). This entry's `header` field pointed to the same unreachable `biotechwithoutborders.org` host, so the carousel kept trying (and failing) to load an image there. `header` is also used as this entry's own page banner, which was equally broken — removing the field fixes both.

**Full-site audit for context:** I checked every entry across all 8 collections (`_labs`, `_projects`, `_startups`, `_incubators`, `_groups`, `_networks`, `_events`, `_others`) for a `promotions` block with a usable image. Only three exist site-wide: BUGSS, BiohackUIO, and this one. With this fix, the carousel's candidate pool is down to those first two (plus the hardcoded DIYbiosphere intro slide) — both confirmed **Active** in the recent audit with working images. That's already a minimal, relevant set; no further trimming needed unless new promotions get added later without verifying the image first.

## Test plan
- [ ] Confirm the homepage carousel no longer attempts to load any biotechwithoutborders.org image
- [ ] Confirm Biotech Without Borders' own entry page renders without a broken banner image

🤖 Generated with [Claude Code](https://claude.com/claude-code)