### PR TITLE
Remove Twitter section from Contact Us page

### DIFF
--- a/about/contact.md
+++ b/about/contact.md
@@ -7,7 +7,3 @@ As part of [our values] we strive to maintain our communication as public as pos
 
 ### GitHub Issues
 We use GitHub's Issues to organize and manage the development of the project. The majority of conversations related to the project should happen here. The [Issues] are public, but in order to submit a new issue you need a GitHub account ([sign up](https://github.com/join)). You can submit a question, suggestion, or a [request to join][join] the DIYbiosphere organization.
-
-
-### Twitter
-For the moment our Twitter account it is somewhat inactive during alpha release. Once we go to beta release we will set up some automatic tweets for every new entry added to the library.


### PR DESCRIPTION
## Summary
- Removes the "### Twitter" section from `/about/contact/`, which described the account as "somewhat inactive during alpha release."

🤖 Generated with [Claude Code](https://claude.com/claude-code)