### PR TITLE
Remove unfinished info box and empty stub sections from Understanding Entries

### DIFF
--- a/docs/basics/entries.md
+++ b/docs/basics/entries.md
@@ -46,9 +46,6 @@ The _type_ is for specifying the kind of social/legal configuration of the initi
 - _school_
 - _museum_
 
-
-{% include messages/info.html title="The meaning behind type" text="The idea behind `type: ` is..." %}
-
 ## Tags
 The _tags_ are keywords that describe entries. Tags are not predetermined but should be as standardized as possible. There might be overlaps as some people may write the _collection_ name, or the _type_ as a _tag_. These should standardize and an assessment should follow to determine if new _collections_, or _types_ should be created.
 
@@ -63,9 +60,3 @@ The _status_ should be completely standardized and should only have one of the f
 - _active_
 - _inactive_
 - _planned_
-
-# Other data keys
-{% include messages/incomplete.html %}
-
-# Rendering the Entries
-{% include messages/incomplete.html %}


### PR DESCRIPTION
## Summary
- "The meaning behind type" info box was a placeholder that never got written ("The idea behind \`type: \` is...")
- "Other data keys" and "Rendering the Entries" were bare headings with nothing but the \`{% include messages/incomplete.html %}\` stub, which renders as "This section is still incomplete. Please consider adding content if you can!!" — reads as a mistake to a visitor rather than a useful TODO

🤖 Generated with [Claude Code](https://claude.com/claude-code)