### PR TITLE
Remove the "Searching for entries" section from Getting Started

### DIFF
--- a/docs/introduction/getting-started.md
+++ b/docs/introduction/getting-started.md
@@ -6,50 +6,6 @@ toc: true
 ---
 
 
-# Searching for entries
-## Quick search
-The search bar in the navigation menu at the top is to **quick search** for entries. Search by `title:` and/or location (`city:` and `country:`). The query will also display and search the `hosts:` of an entry if any. The search will try to autocomplete the query as five suggestions are listed below the search bar.
-
-![](/docs/introduction/quick-search.png){:.ui.bordered.centered.image }
-
-## Advanced search (browse)
-Select the `BROWSE` dropdown in the top navigation menu. Select either to view all entries (`everything`), or narrow by _collection_.
-
-Once in the _browse_ page, there are three main sections: the **query statistics** the **browse menu** and the **displayed results**.
-
-![](/docs/introduction/search-query.png){:.ui.bordered.centered.image }
-
-### Query statistics
-The number of entries found is displayed, as well as any additional **text search** or **filter results** **view settings**. The filters can be removed by selecting each, or select the `Erase all` to remove all filters.
-
-![](/docs/introduction/filter-query.png){:.ui.bordered.centered.image }
-
-### Browse menu
-A dropdown grey menu unfolds to display the various configuration options to browse entries.
-
-![](/docs/introduction/browse-menu.png){:.ui.bordered.centered.image }
-
-- **Text search** unfolds automatically. The query will search for _text_ inside the entries, as well as data such as `title:`, `city:`, `state:`, etc.
-
-![](/docs/introduction/query-menu.png){:.ui.large.bordered.centered.image }
-
-- **Filter results** by `status:`, `collection:`, `type:`, `country:`, and `tags:`. Each filter selection works with an OR selection.
-
-_ **View Settings** to select _number of page_, _results per page_, _sorting_, and _view format_
-
-![](/docs/introduction/view-query.png){:.ui.big.bordered.centered.image }
-
-### Displayed results
-See the results in two formats: as a _list_, or a _table_
-
-![](/docs/introduction/list-hit.png){:.ui.large.bordered.centered.image }
-
-![](/docs/introduction/table-hit.png){:.ui.huge.bordered.centered.image }
-
-
-{% include messages/star.html title="Future hit map" text="The API for displaying results (Algolia instantsearch.js) is currently developing a GeoSearch widget, we are waiting for its release" %}
-
-
 # Contributing to the project
 ## Writing Entries
 Following the tutorials you can [add] a new entry: whether it's your initiative or someone else's,  or [edit] content: misspellings, outdated or wrong information, help us maintain the project. Every change goes through a pull request, which a maintainer reviews before merging.


### PR DESCRIPTION
## Summary
- Removes the Quick search / Advanced search (browse) explainer from `/docs/introduction/getting-started/` — a docs page walking through how to use a search bar and filter UI isn't adding value. Contributing to the project and Downloading the dataset sections are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)