### PR TITLE
Point Hackuarium's carousel link to their website

### DIFF
--- a/_labs/Hackuarium/Hackuarium.md
+++ b/_labs/Hackuarium/Hackuarium.md
@@ -6,7 +6,7 @@ website: http://www.hackuarium.ch/en/
 promotions:
   - button: Join our Open Meetups
     text: 'Come visit on _OpenHackuarium_ night every Wednesday, from 7:30-10:30 '
-    URL: http://wiki.hackuarium.ch/w/Main_Page
+    URL: https://www.hackuarium.ch/
 start-date: 2014
 hosts: '[UniverCite](http://univercity.ch/)'
 address: Chemin du Closel 5


### PR DESCRIPTION
## Summary
- Hackuarium's homepage carousel promotion ("Join our Open Meetups") linked to their old wiki (wiki.hackuarium.ch) instead of their actual website. Updated to https://www.hackuarium.ch/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)