### PR TITLE
Replace dead Google Analytics (UA) with the current GA4 tag

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,5 +1,15 @@
 <head>
 
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-X8S7RY89Q1"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-X8S7RY89Q1');
+  </script>
+
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -27,15 +37,5 @@
 
   <script src="{{ site.baseurl }}/assets/js/vendor/fontawesome-all.js"></script>
   <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:400,600" rel="stylesheet">
-
-  <script> <!-- Google analytics -->
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-    ga('create', 'UA-78642734-1', 'auto');
-    ga('send', 'pageview');
-  </script>
 
 </head>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,9 +20,6 @@
       };
     </script>
 
-      <!-- Google Analytics -->
-    <script src="https://www.google.com/jsapi"></script>
-
       <!-- JQuery & Semantic UI -->
     <script src="https://code.jquery.com/jquery-2.2.2.min.js" integrity="sha256-36cp2Co+/62rEAAYHLmRCPIych47CvdM+uTBJwSzWjI="   crossorigin="anonymous"></script>
     <script src="/assets/semantic/dist/semantic.min.js"></script>


### PR DESCRIPTION
## Summary
- \`_includes/head.html\` loaded the classic Universal Analytics snippet (\`analytics.js\`, property \`UA-78642734-1\`). Google fully decommissioned UA data processing on **July 1, 2023**, so this had been firing on every page view for ~3 years while collecting nothing — silently dead, no error.
- Replaced it with the current \`gtag.js\` snippet (property \`G-X8S7RY89Q1\`), placed right after \`<head>\` per Google's recommended placement.
- Also removed a separate script in \`_layouts/default.html\` mislabeled "Google Analytics" — it actually loads \`google.com/jsapi\`, Google's old deprecated API loader (unrelated to analytics, last relevant ~2015), with nothing else in the codebase using it.

## Test plan
- [ ] Confirm pages render with no console errors
- [ ] Confirm the GA4 property (G-X8S7RY89Q1) starts showing realtime traffic after this deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)