### PR TITLE
Remove links to hijacked/squatted domains outside Labs

### DIFF
--- a/_events/TECNOx30/TECNOx30.md
+++ b/_events/TECNOx30/TECNOx30.md
@@ -1,7 +1,7 @@
 ---
 title: TECNOx 3.0
 subtitle: Free technologies for Latin America
-website: http://tecnox.org/ 
+website:
 start-date: April 16 to 21, 2018
 type-org: Organization
 city: Valparaiso

--- a/_groups/BioHubIl/BioHubIl.md
+++ b/_groups/BioHubIl/BioHubIl.md
@@ -1,6 +1,6 @@
 ---
 title: BioHubIl
-website: http://biohubil.org/
+website:
 start-date: 2015
 type-org: non-profit
 address: Rothschild Boulevard 3

--- a/_networks/SyntechBio/SyntechBio.md
+++ b/_networks/SyntechBio/SyntechBio.md
@@ -1,7 +1,7 @@
 ---
 title: SynTechBio Network
 subtitle:
-website: https://www.syntechbio.com/
+website:
 start-date:
 type-org:
 city:

--- a/_startups/Chronomed/Chronomed.md
+++ b/_startups/Chronomed/Chronomed.md
@@ -1,7 +1,7 @@
 ---
 title: Chronomed
 subtitle:
-website: http://www.chronomed.nl/
+website:
 start-date: 2016
 type-org: Company
 city: Amsterdam

--- a/_startups/ConectorCiencia/ConectorCiencia.md
+++ b/_startups/ConectorCiencia/ConectorCiencia.md
@@ -6,9 +6,8 @@ start-date: 2017-11-11
 # end-date: ongoing # 'ongoing' is an invalid value for this field, it needs to be a 'date string'
 hosts:
   - Conector Ciência # Exact `title: `of DIYbiosphere
-  - "[Conector Ciência](http://www.conecien.com/english_page.html)" # link to a local page in markdown link wrapped in ""
 partners:
-  - '[Syntechbio Network](https://www.syntechbio.com/)' # link to external website in markdown link wrapped in ''
+  - 'Syntechbio Network' # website removed - domain now dead/parked
   - '[Tech Trash](https://www.techtrashbrasil.com.br/)' # link to external website in markdown link wrapped in ''
   - '[Rede de Pesquisadores](https://www.rededepesquisadores.org/)' # link to external website in markdown link wrapped in ''
 type-org: start-up
@@ -22,7 +21,7 @@ tags:
   - Education
   - DNA
   - citizen science
-website: http://www.conecien.com/  
+website:
 instagram: https://www.instagram.com/conector_ciencia/
 facebook: https://www.facebook.com/conectorciencia/
 ---

--- a/_startups/FoliumBiosciences/FoliumBiosciences.md
+++ b/_startups/FoliumBiosciences/FoliumBiosciences.md
@@ -1,7 +1,7 @@
 ---
 title: Folium Biosciences
 subtitle: 
-website: https://foliumbiosciences.com/
+website:
 start-date: 2015
 type-org: Company/Start-up
 city: Colorado Springs

--- a/_startups/ProspectiveResearch/ProspectiveResearch.md
+++ b/_startups/ProspectiveResearch/ProspectiveResearch.md
@@ -1,7 +1,7 @@
 ---
 title: Prospective Research
 subtitle: Commercializing The Language Of Bacteria
-website: https://www.prospectiveresearch.com/read-me/ 
+website:
 start-date: 
 type-org: Company/Start-up
 city: Beverly

--- a/_startups/feles/Feles.md
+++ b/_startups/feles/Feles.md
@@ -1,7 +1,7 @@
 ---
 title: Feles
 subtitle: Build desktop biolabs for everyone
-website: http://www.felesbio.com
+website:
 start-date: 2018-07-01
 type-org: Company/Startup
 address: 625 Massachusetts Avenue, 


### PR DESCRIPTION
## Summary
Follow-up to the Labs domain-squat cleanup — the full 188-entry directory audit surfaced 7 more entries whose `website` link now points somewhere unrelated and unsafe:

| Entry | Collection | What the link now serves |
|---|---|---|
| Chronomed | Startups | Unrelated Dutch sleep-advice content farm |
| Folium Biosciences | Startups | Freshly squatted domain, no real content |
| Prospective Research | Startups | Russian-language gambling/casino site |
| Feles | Startups | Unrelated spam/affiliate content (wedding transport, etc.) |
| Conector Ciência | Startups | Redirects to a gambling site; also dropped a dead link to Syntechbio Network in its `hosts`/`partners` fields |
| BioHubIl | Groups | Unrelated medical-spam content farm |
| SynTechBio Network | Networks | Domain returns 410 Gone / parked, no real content |
| TECNOx | Events | Real conference content, but interleaved with injected gambling/spam pages (compromised site) |

Each was checked directly (`curl`/page title) before touching it, not just flagged from the earlier automated pass. **Biodidact** was flagged too but is NOT touched here — its old domain 301s to "The Community Lab," which looks like a legitimate rebrand, not a squat.

Entries are left intact as historical directory records — only the compromised link fields were removed.

## Test plan
- [x] Diffed each file — only the flagged link fields changed, nothing else
- [x] Verified live destination of each URL via curl/title before removing