### PR TITLE
Set explicit status across the remaining 7 collections

### DIFF
--- a/_events/BBKOpenScience/BBKOpenScience.md
+++ b/_events/BBKOpenScience/BBKOpenScience.md
@@ -1,5 +1,6 @@
 ---
 title: BBK Open Science
+status: active
 subtitle: Festival de la Ciencia Abierta y Participativa (Participatory and Open Science Festival)
 website: https://bbkopenscience.com/
 start-date: 2019-01-18

--- a/_events/BioDesignChallenge/BioDesignChallenge.md
+++ b/_events/BioDesignChallenge/BioDesignChallenge.md
@@ -1,5 +1,6 @@
 ---
 title: Bio Design Challenge
+status: active
 subtitle: learn. create. grow.
 website: http://biodesignchallenge.org/
 start-date: 2016

--- a/_events/BioFabbing/BioFabbing.md
+++ b/_events/BioFabbing/BioFabbing.md
@@ -1,5 +1,6 @@
 ---
 title: BioFabbing Convergence
+status: inactive
 website: http://citizensciences.net/biofabbing/
 start-date: 2017-05-10
 end-date: 2017-05-14

--- a/_events/BioHTP/BioHTP.md
+++ b/_events/BioHTP/BioHTP.md
@@ -1,5 +1,6 @@
 ---
 title: Biohack The Planet
+status: unknown
 subtitle: create something beautiful
 website: http://biohacktheplanet.com/
 start-date: 2016

--- a/_events/GatheringForOpenScienceHardware/GatheringForOpenScienceHardware.md
+++ b/_events/GatheringForOpenScienceHardware/GatheringForOpenScienceHardware.md
@@ -1,5 +1,6 @@
 ---
 title: Gathering For Open Science Hardware
+status: active
 subtitle: GOSH
 website: http://openhardware.science/ 
 start-date: 2018-09-01

--- a/_events/GlobalCommunityBioSummit/GlobalCommunityBioSummit.md
+++ b/_events/GlobalCommunityBioSummit/GlobalCommunityBioSummit.md
@@ -1,5 +1,6 @@
 ---
 title: Global Community BioSummit
+status: active
 subtitle:
 website: https://www.biosummit.org/
 start-date: 2017

--- a/_events/HOPE/HackersOnPlanetEarth.md
+++ b/_events/HOPE/HackersOnPlanetEarth.md
@@ -1,5 +1,6 @@
 ---
 title: Hope Conference
+status: active
 subtitle: Hackers On Planet Earth
 website: http://hope.net/
 start-date: 1994

--- a/_events/Igem/Igem.md
+++ b/_events/Igem/Igem.md
@@ -1,5 +1,6 @@
 ---
 title: iGEM
+status: active
 subtitle: synthetic biology based on standard parts
 website: http://igem.org/
 start-date: 2003

--- a/_events/NationOfMakersConference/NationOfMakersConference.md
+++ b/_events/NationOfMakersConference/NationOfMakersConference.md
@@ -1,5 +1,6 @@
 ---
 title: Nation Of Makers Conference
+status: unknown
 subtitle: Collaborative Community-Wide Maker Convening
 website: https://www.nomcon.org/
 start-date: June 9-10, 2018

--- a/_events/NewHarvest/NewHarvest.md
+++ b/_events/NewHarvest/NewHarvest.md
@@ -1,5 +1,6 @@
 ---
 title: New Harvest
+status: active
 subtitle:
 website: http://www.new-harvest.org/ 
 start-date: 2017

--- a/_events/PoreCamp/PoreCampVancouver.md
+++ b/_events/PoreCamp/PoreCampVancouver.md
@@ -1,5 +1,6 @@
 ---
 title: PoreCamp
+status: unknown
 subtitle: A Training Bootcamp Based On The Oxford Nanopore MinION
 website: http://porecamp.github.io/
 start-date: 2015

--- a/_events/SynBioBeta/SynBioBeta.md
+++ b/_events/SynBioBeta/SynBioBeta.md
@@ -1,5 +1,6 @@
 ---
 title: SynBioBeta
+status: active
 subtitle: The Synthetic Biology Innovation Network
 website: https://synbiobeta.com/ 
 start-date: October 1-3, 2018

--- a/_events/TECNOx30/TECNOx30.md
+++ b/_events/TECNOx30/TECNOx30.md
@@ -1,5 +1,6 @@
 ---
 title: TECNOx 3.0
+status: inactive
 subtitle: Free technologies for Latin America
 website:
 start-date: April 16 to 21, 2018

--- a/_events/africaOSH/africaOSH.md
+++ b/_events/africaOSH/africaOSH.md
@@ -1,5 +1,6 @@
 ---
 title: Africa Open Science Hardware Summit
+status: active
 subtitle: "Making / Hacking / Bio-Hacking"
 website: http://www.africaosh.com/
 start-date: 2018

--- a/_groups/BeInToBiohacking/BeInToBiohacking.md
+++ b/_groups/BeInToBiohacking/BeInToBiohacking.md
@@ -1,5 +1,6 @@
 ---
 title: Be.In.To
+status: unknown
 tags:
 - fablab
 - hackerspace

--- a/_groups/BioHackSyd/BioHackSyd.md
+++ b/_groups/BioHackSyd/BioHackSyd.md
@@ -1,5 +1,6 @@
 ---
 title: BioHackSyd
+status: unknown
 subtitle: Syney Biohackers Meeting
 start-date: 2015
 type-org: community

--- a/_groups/BioHubIl/BioHubIl.md
+++ b/_groups/BioHubIl/BioHubIl.md
@@ -1,5 +1,6 @@
 ---
 title: BioHubIl
+status: inactive
 website:
 start-date: 2015
 type-org: non-profit

--- a/_groups/BioTinkeringBerlin/BioTinkeringBerlin.md
+++ b/_groups/BioTinkeringBerlin/BioTinkeringBerlin.md
@@ -1,5 +1,6 @@
 ---
 title: Biotinkering Berlin
+status: inactive
 website: https://www.biotinkering-berlin.de/?lang=en
 start-date: 2014
 hosts: "[Art Laboratory Berlin](http://artlaboratory-berlin.org/home.htm)"

--- a/_groups/Biogarage/Biogarage.md
+++ b/_groups/Biogarage/Biogarage.md
@@ -1,5 +1,6 @@
 ---
 title: Biogarage
+status: inactive
 subtitle: Das Do It Yourself Labor
 website: http://biogarage.de/
 start-date: 2013

--- a/_groups/BiohackersNYC/BiohackersNYC.md
+++ b/_groups/BiohackersNYC/BiohackersNYC.md
@@ -1,5 +1,6 @@
 ---
 title: Biohackers NYC
+status: inactive
 tags:
 - transhumanism
 subtitle: human performance optimized

--- a/_groups/Biook/Biook.md
+++ b/_groups/Biook/Biook.md
@@ -1,5 +1,6 @@
 ---
 title: Biook
+status: active
 subtitle:
 website: www.biook.org
 host: '[BBK Open Science](www.bbkopenscience.com)'

--- a/_groups/CapCityBiohackers/CapCityBiohackers.md
+++ b/_groups/CapCityBiohackers/CapCityBiohackers.md
@@ -1,5 +1,6 @@
 ---
 title: Cap City Biohackers
+status: unknown
 website: http://www.capcitybiohackers.org/
 start-date: 2015
 hosts: "[Rev1 Ventures](https://www.rev1ventures.com/)"

--- a/_groups/ChicagoBiohacking/ChicagoBiohacking.md
+++ b/_groups/ChicagoBiohacking/ChicagoBiohacking.md
@@ -1,5 +1,6 @@
 ---
 title: DIYbio Chicago
+status: inactive
 start-date: 2013
 type-org: community
 city: Chicago

--- a/_groups/DIYNeurotech/DIYNeurotech.md
+++ b/_groups/DIYNeurotech/DIYNeurotech.md
@@ -1,5 +1,6 @@
 ---
 title: DIY Neurotech
+status: inactive
 tags:
 - neurology
 - transhumanism

--- a/_groups/DIYbioBelgium/DIYbioBelgium.md
+++ b/_groups/DIYbioBelgium/DIYbioBelgium.md
@@ -1,5 +1,6 @@
 ---
 title: DIYbio Belgium
+status: inactive
 website: http://www.diybio.be/
 start-date: 2012
 end-date: 2014

--- a/_groups/DIYbioBuenosAires/DIYbioBuenosAires.md
+++ b/_groups/DIYbioBuenosAires/DIYbioBuenosAires.md
@@ -1,5 +1,6 @@
 ---
 title: Biohacking BA
+status: unknown
 website: www.diybioba.org
 start-date: 2015
 city: Buenos Aires

--- a/_groups/DIYbioGroningen/DIYbioGroningen.md
+++ b/_groups/DIYbioGroningen/DIYbioGroningen.md
@@ -1,5 +1,6 @@
 ---
 title: DIYbio Groningen
+status: unknown
 subtitle: A vribrant community of makers, hackers, and do-it-yourself biologists
 website: http://www.diybiogroningen.org/
 start-date: 2013

--- a/_groups/DIYbioIreland/DIYbioIreland.md
+++ b/_groups/DIYbioIreland/DIYbioIreland.md
@@ -1,5 +1,6 @@
 ---
 title: DIYbio Ireland
+status: inactive
 start-date: 2011
 end-date: 2015
 successor: Forma Labs

--- a/_groups/DIYbioIsrael/DIYbioIsrael.md
+++ b/_groups/DIYbioIsrael/DIYbioIsrael.md
@@ -1,5 +1,6 @@
 ---
 title: DIYbio Israel
+status: inactive
 start-date: 2013
 end-date: 2016
 successor: BioHubIl

--- a/_groups/DIYbioMexico/DIYbioMexico.md
+++ b/_groups/DIYbioMexico/DIYbioMexico.md
@@ -1,5 +1,6 @@
 ---
 title: DIYbio Mexico
+status: unknown
 website:
 start-date:
 type-org: community

--- a/_groups/DIYbioPerth/DIYbioPerth.md
+++ b/_groups/DIYbioPerth/DIYbioPerth.md
@@ -1,5 +1,6 @@
 ---
 title: DIYbio Perth
+status: unknown
 tags:
 - makerspace
 start-date:

--- a/_groups/DIYbioSingapore/DIYbioSingapore.md
+++ b/_groups/DIYbioSingapore/DIYbioSingapore.md
@@ -1,5 +1,6 @@
 ---
 title: DIYbio Singapore
+status: unknown
 website: https://diybiosingapore.wordpress.com/
 start-date: 2010
 type-org: community

--- a/_groups/GeneGarage/GeneGarage.md
+++ b/_groups/GeneGarage/GeneGarage.md
@@ -1,5 +1,6 @@
 ---
 title: Gene Garage
+status: inactive
 website:
 start-date: 2015
 hosts: Tecnologico de Monterrey, Campus Guadalajara

--- a/_groups/Hackstronauts/Hackstronauts.md
+++ b/_groups/Hackstronauts/Hackstronauts.md
@@ -1,5 +1,6 @@
 ---
 title: Hackstronauts
+status: active
 tags:
 - transhumanism
 - nootropics

--- a/_groups/LeBiomeHackLab/LeBiomeHackLab.md
+++ b/_groups/LeBiomeHackLab/LeBiomeHackLab.md
@@ -1,5 +1,6 @@
 ---
 title: Biome Hack Lab
+status: unknown
 tags:
 - biomimicry
 website: https://lebiome.github.io/

--- a/_groups/MNDIYbio/MNDIYbio.md
+++ b/_groups/MNDIYbio/MNDIYbio.md
@@ -1,5 +1,6 @@
 ---
 title: MN DIYbio
+status: unknown
 manager:
 mott: The Minnesota Biology Group
 logo:

--- a/_groups/ManilaBiopunk/ManilaBiopunk.md
+++ b/_groups/ManilaBiopunk/ManilaBiopunk.md
@@ -1,5 +1,6 @@
 ---
 title: Manila Biopunk
+status: inactive
 website: http://www.manilabiopunk.org/
 start-date: 2014
 type-org: community

--- a/_groups/MikroBiomik/MikroBiomik.md
+++ b/_groups/MikroBiomik/MikroBiomik.md
@@ -1,5 +1,6 @@
 ---
 title: MikroBiomik
+status: active
 website: https://mikrobiomik.org/en
 start-date: 2017
 type-org: community

--- a/_groups/Singularity/Singularity.md
+++ b/_groups/Singularity/Singularity.md
@@ -1,5 +1,6 @@
 ---
 title: Singularity
+status: active
 start-date: 2023
 type-org: group
 location: León, México

--- a/_groups/TheWetlab/TheWetlab.md
+++ b/_groups/TheWetlab/TheWetlab.md
@@ -1,5 +1,6 @@
 ---
 title: The Wet Lab
+status: unknown
 start-date: 2013
 website: http://www.sdwetlab.org/
 type-org: community

--- a/_groups/TriDIYbio/TriDIYbio.md
+++ b/_groups/TriDIYbio/TriDIYbio.md
@@ -1,5 +1,6 @@
 ---
 title: Triangle DIY Biology
+status: active
 subtitle: Community Citizen Science and DIYbio Group of the NC Triangle
 website: http://www.tridiybio.org/
 start-date: 2015

--- a/_incubators/BerkleyBiolabs/BerkleyBiolabs.md
+++ b/_incubators/BerkleyBiolabs/BerkleyBiolabs.md
@@ -1,5 +1,6 @@
 ---
 title: Berkley Biolabs
+status: unknown
 website: http://www.berkeleybiolabs.com/
 start-date: 2013
 address: 614 Bancroft Way

--- a/_incubators/BioRiiDL/BioRiiDL.md
+++ b/_incubators/BioRiiDL/BioRiiDL.md
@@ -1,5 +1,6 @@
 ---
 title: BioRiiDL
+status: unknown
 subtitle:
 website: http://www.bioriidl.org/
 start-date: 2017

--- a/_incubators/BioTechAndBeyond/BioTechAndBeyond.md
+++ b/_incubators/BioTechAndBeyond/BioTechAndBeyond.md
@@ -1,5 +1,6 @@
 ---
 title: Bio, Tech and Beyond
+status: unknown
 subtitle: North San Diego's Life Science Incubator
 logo: https://pbs.twimg.com/profile_images/378800000013265781/54d57c46545546ea46e02c8be2d76716_400x400.jpeg
 website: http://www.biotechnbeyond.com/

--- a/_incubators/BlueCity/BlueCity.md
+++ b/_incubators/BlueCity/BlueCity.md
@@ -1,5 +1,6 @@
 ---
 title: Blue City Lab
+status: active
 website: http://www.bluecity.nl/
 start-date: 2017
 hosts: Blue City

--- a/_incubators/HarlemBiospace/HarlemBiospace.md
+++ b/_incubators/HarlemBiospace/HarlemBiospace.md
@@ -1,5 +1,6 @@
 ---
 title: Harlem Biospace
+status: active
 subtitle: An affordable co-working wet lab, right in Manhattan
 logo: https://scontent-mxp1-1.xx.fbcdn.net/v/t1.0-1/p200x200/12924577_564699273690469_5064291978652898101_n.jpg?oh=1324142ed1d1edfd76437ad3b409b451&oe=590B1CCE
 website: http://harlembiospace.com/

--- a/_incubators/Hax/Hax.md
+++ b/_incubators/Hax/Hax.md
@@ -1,5 +1,6 @@
 ---
 title: Hax Accelerator
+status: inactive
 subtitle: In the heart of the Silicon Valley for hardware
 website: https://hax.co/accelerator/
 start-date:

--- a/_incubators/IndieBio/IndieBio.md
+++ b/_incubators/IndieBio/IndieBio.md
@@ -1,5 +1,6 @@
 ---
 title: IndieBio
+status: inactive
 subtitle: Accelerating Biology
 website: http://indiebio.co/
 start-date: 2010

--- a/_incubators/RebelBio/RebelBio.md
+++ b/_incubators/RebelBio/RebelBio.md
@@ -1,5 +1,6 @@
 ---
 title: RebelBio
+status: inactive
 subtitle: The world's first life sciences accelerator.
 website: https://rebelbio.co/
 start-date: 2010

--- a/_incubators/ToolFoundry/ToolFoundry.md
+++ b/_incubators/ToolFoundry/ToolFoundry.md
@@ -1,5 +1,6 @@
 ---
 title: Tool Foundry
+status: inactive
 subtitle: Advancing accessible tools for scientific discovery
 website: https://www.toolfoundry.org/ 
 start date: 2019-04-01

--- a/_networks/BioChanges/BioChanges.md
+++ b/_networks/BioChanges/BioChanges.md
@@ -1,5 +1,6 @@
 ---
 title: BioChanges BioDesign
+status: inactive
 partners:
   - BioDesign Studios
   - BioMaker Spaces

--- a/_networks/BioDesignFTRW/BioDesignFTRW.md
+++ b/_networks/BioDesignFTRW/BioDesignFTRW.md
@@ -1,5 +1,6 @@
 ---
 title: Biodesign for the Real World
+status: unknown
 logo: https://filopodia.files.wordpress.com/2013/10/cropped-biodesign-logo-green.png
 website: https://biodesign.cc/
 start-date:

--- a/_networks/CitizenScienceGlobalPartnership/CitizenScienceGlobalPartnership.md
+++ b/_networks/CitizenScienceGlobalPartnership/CitizenScienceGlobalPartnership.md
@@ -1,5 +1,6 @@
 ---
 title: Citizen Science Global Partnership
+status: active
 subtitle: A network-of-networks that seeks to promote and advance citizen science for a sustainable world
 website: http://citizenscienceglobal.org
 start-date: 2017-12-1

--- a/_networks/DIYbio.org/DIYbio.org.md
+++ b/_networks/DIYbio.org/DIYbio.org.md
@@ -1,5 +1,6 @@
 ---
 title: DIYbio.org
+status: active
 subtitle: Biotechnology and greater public understanding about it has the potential to benefit everyone.
 website: http://diybio.org/
 start-date: 2008

--- a/_networks/Degenics/Degenics.md
+++ b/_networks/Degenics/Degenics.md
@@ -1,6 +1,7 @@
 ---
 draft: true
 title: Degenics 
+status: inactive
 subtitle: An anonymous, decentralized marketplace for personal genetic testing - built on the Polkadot blockchain.
 start-date: 2020
 hosts:

--- a/_networks/Hackteria/Hackteria.md
+++ b/_networks/Hackteria/Hackteria.md
@@ -1,5 +1,6 @@
 ---
 title: Hackteria
+status: active
 subtitle:
 website: https://www.hackteria.org/
 start-date: 2009

--- a/_networks/JOGL/JOGL.md
+++ b/_networks/JOGL/JOGL.md
@@ -1,6 +1,7 @@
 ---
 draft: true
 title: Just One Giant Lab (JOGL.io)
+status: active
 subtitle:
 start-date: 2018
 hosts:

--- a/_networks/NYCBio/NYCBio.md
+++ b/_networks/NYCBio/NYCBio.md
@@ -14,7 +14,7 @@ type-org: non-profit
 city: New York
 state: New York
 country: United States
-status: inactive
+status: unknown
 linkedin: https://www.linkedin.com/groups/41295/profile
 ---
 

--- a/_networks/OpenBioMedicalInitiative/OpenBioMedicalInitiative.md
+++ b/_networks/OpenBioMedicalInitiative/OpenBioMedicalInitiative.md
@@ -1,5 +1,6 @@
 ---
 title: Open BioMedical Initiative
+status: unknown
 subtitle:
 website: http://www.openbiomedical.org/
 start-date: 2014

--- a/_networks/SyntechBio/SyntechBio.md
+++ b/_networks/SyntechBio/SyntechBio.md
@@ -1,5 +1,6 @@
 ---
 title: SynTechBio Network
+status: inactive
 subtitle:
 website:
 start-date:

--- a/_others/BioLinkDepot/BioLinkDepot.md
+++ b/_others/BioLinkDepot/BioLinkDepot.md
@@ -1,5 +1,6 @@
 ---
 title: BioLink Depot
+status: active
 subtitle: Donating Science Supplies to Schools
 website: http://biolinkdepot.org/
 start-date: 2002

--- a/_others/MaraRenewables/MaraRenewables.md
+++ b/_others/MaraRenewables/MaraRenewables.md
@@ -1,6 +1,7 @@
 ---
 draft: true
 title: Mara Renewables
+status: active
 subtitle:
 start-date: 2006
 hosts:

--- a/_others/fusionbiotec/FusionBiotec.md
+++ b/_others/fusionbiotec/FusionBiotec.md
@@ -1,6 +1,7 @@
 ---
 draft: true
 title: Fusion Biotec
+status: inactive
 subtitle:
 start-date: 2016
 hosts:

--- a/_others/ginkgoBioworks/ginkgobioworks.md
+++ b/_others/ginkgoBioworks/ginkgobioworks.md
@@ -1,5 +1,6 @@
 ---
 title: Ginkgo Bioworks
+status: active
 subtitle: The organism company.
 start-date: 2009
 hosts:

--- a/_others/iHUB/iHUB.md
+++ b/_others/iHUB/iHUB.md
@@ -1,5 +1,6 @@
 ---
 title: Instituto HUB
+status: unknown
 website: http://ihub.org.br/
 start-date: 2016
 

--- a/_projects/BioArtBot/BioArtBot.md
+++ b/_projects/BioArtBot/BioArtBot.md
@@ -1,6 +1,7 @@
 ---
 draft: true
 title: BioArtBot
+status: unknown
 subtitle: Make BioArt with Robots!
 start-date: 2019
 hosts:

--- a/_projects/BioDisplay/BioDisplay.md
+++ b/_projects/BioDisplay/BioDisplay.md
@@ -1,5 +1,6 @@
 ---
 title: Biodisplay
+status: unknown
 ---
 
 ## About

--- a/_projects/BooleanBiotech/BooleanBiotech.md
+++ b/_projects/BooleanBiotech/BooleanBiotech.md
@@ -1,5 +1,6 @@
 ---
 title: Boolean Biotech
+status: active
 subtitle:
 website: http://blog.booleanbiotech.com/
 start-date: 2014

--- a/_projects/CSAEthics/CSAEthics.md
+++ b/_projects/CSAEthics/CSAEthics.md
@@ -1,5 +1,6 @@
 ---
 title: CSA Ethics Working Group Resource Collection
+status: unknown
 subtitle: Please contribute and utilize ethics tools for DIY science (templates, tech, training, papers, etc)
 start-date: 2017
 hosts:

--- a/_projects/DecentralizedOxalisGenomeProject/DecentralizedOxalisGenomeProject.md
+++ b/_projects/DecentralizedOxalisGenomeProject/DecentralizedOxalisGenomeProject.md
@@ -1,5 +1,6 @@
 ---
 title: Decentralized Oxalis Genome Project
+status: unknown
 subtitle:
 website: https://www.facebook.com/oxalisgenome/
 start-date: 2016

--- a/_projects/GenespaceOptogenetics/GenspacesOptogeneticsCommunityProject.md
+++ b/_projects/GenespaceOptogenetics/GenspacesOptogeneticsCommunityProject.md
@@ -1,6 +1,7 @@
 ---
 draft: true
 title: Genspace's Optogenetics Community Project
+status: inactive
 hosts:
   - DIYbiosphere
 partners:

--- a/_projects/Genspace/GenspacesOpenPlantCommunityProject.md
+++ b/_projects/Genspace/GenspacesOpenPlantCommunityProject.md
@@ -1,6 +1,7 @@
 ---
 draft: true
 title: Genspace's Open Plant Community Project
+status: unknown
 hosts:
   - DIYbiosphere
 partners:

--- a/_projects/InteractiveMyceliumLights/InteractiveMyceliumLights.md
+++ b/_projects/InteractiveMyceliumLights/InteractiveMyceliumLights.md
@@ -1,5 +1,6 @@
 ---
 title: Interactive Mycelium Lights
+status: unknown
 subtitle: This is an ongoing project to intetegrate interactive lights and boards with mycelium lights
 website: https://www.sweeneyartist.com/
 start-date: 2019-02-16

--- a/_projects/KombuchaGenomics/KombuchaGenomics.md
+++ b/_projects/KombuchaGenomics/KombuchaGenomics.md
@@ -1,5 +1,6 @@
 ---
 title: Kombucha Genomics
+status: unknown
 subtitle:
 website:
 start-date: 2017-11-14

--- a/_projects/Metafluidics/Metafluidics.md
+++ b/_projects/Metafluidics/Metafluidics.md
@@ -1,5 +1,6 @@
 ---
 title: Metafluidics
+status: unknown
 subtitle: An open repository for fluidic systems
 website: https://metafluidics.org/
 start-date: 2017

--- a/_projects/OYEP/OYEP.md
+++ b/_projects/OYEP/OYEP.md
@@ -1,5 +1,6 @@
 ---
 title: 'OYEP: Open Yeast Engineering Project'
+status: unknown
 subtitle: Bringing Yeast Engineering to the Masses
 website: https://github.com/oyep/oyep
 start-date: 2017

--- a/_projects/OpenGenX/OpenGenX.md
+++ b/_projects/OpenGenX/OpenGenX.md
@@ -1,5 +1,6 @@
 ---
 title: Opengenx
+status: inactive
 website: https://opengenx.wordpress.com/
 ---
 

--- a/_projects/OpenInsulin/OpenInsulin.md
+++ b/_projects/OpenInsulin/OpenInsulin.md
@@ -1,5 +1,6 @@
 ---
 title: Open Insulin
+status: active
 subtitle: We're a team of Bay Area biohackers working on newer, simpler, less expensive ways to make insulin.
 website: http://openinsulin.org/
 start-date: 2015

--- a/_projects/OpenPcr/OpenPcr.md
+++ b/_projects/OpenPcr/OpenPcr.md
@@ -1,5 +1,6 @@
 ---
 title: OpenPCR
+status: unknown
 subtitle: An open source project to make DNA diagnostics and PCR technology available at low-cost
 website: http://openpcr.org/
 start-date: 2010

--- a/_projects/OpenQpcr/OpenQpcr.md
+++ b/_projects/OpenQpcr/OpenQpcr.md
@@ -1,5 +1,6 @@
 ---
 title: Open qPCR
+status: unknown
 subtitle: An open source Real-Time PCR machine, with support for 2 channel multiplexing, amplification curves, and melt curves.
 website: https://www.chaibio.com/openqpcr
 start-date: 2013

--- a/_projects/RealVeganCheese/RealVeganCheese.md
+++ b/_projects/RealVeganCheese/RealVeganCheese.md
@@ -1,5 +1,6 @@
 ---
 title: Real Vegan Cheese
+status: unknown
 subtitle: Biohackers are engineering baker's yeast to produce Real Vegan Cheese. No cows needed!
 website: https://realvegancheese.org/
 start-date: 2014

--- a/_projects/RoninGenetics/RoninGenetics.md
+++ b/_projects/RoninGenetics/RoninGenetics.md
@@ -1,5 +1,6 @@
 ---
 title: Roningenetics
+status: unknown
 ---
 
 ## About

--- a/_projects/diybiosphere/DIYbiosphere.md
+++ b/_projects/diybiosphere/DIYbiosphere.md
@@ -1,5 +1,6 @@
 ---
 title: DIYbiosphere
+status: active
 draft: true
 subtitle: Connecting DIYbio Worldwide
 website: http://sphere.diybio.org/

--- a/_projects/diyhpluswiki/diyhpluswiki.md
+++ b/_projects/diyhpluswiki/diyhpluswiki.md
@@ -1,5 +1,6 @@
 ---
 title: diyhpl.us wiki (diyhpluswiki)
+status: active
 subtitle: a wiki for open source hardware, do-it-yourself biohacking and practical human enhancement engineering projects which could be called transhumanism
 website: https://diyhpl.us/wiki/
 start-date: 2009

--- a/_startups/AlgiKnit/AlgiKnit.md
+++ b/_startups/AlgiKnit/AlgiKnit.md
@@ -1,5 +1,6 @@
 ---
 title: AlgiKnit
+status: active
 subtitle:
 website: https://www.algiknit.com/
 start-date: 2017

--- a/_startups/Allevi/Allevi.md
+++ b/_startups/Allevi/Allevi.md
@@ -1,5 +1,6 @@
 ---
 title: Allevi
+status: inactive
 subtitle: We build tools to design and engineer life.
 website: https://allevi3d.com/
 start-date: 2014

--- a/_startups/AmidBiosciences/AmidBiosciences.md
+++ b/_startups/AmidBiosciences/AmidBiosciences.md
@@ -1,5 +1,6 @@
 ---
 title: Amid Biosciences
+status: active
 subtitle: Competent Cells and Protein
 website: https://amidbiosciences.com/
 start-date: 2016

--- a/_startups/AminoLabs/AminoLabs.md
+++ b/_startups/AminoLabs/AminoLabs.md
@@ -1,5 +1,6 @@
 ---
 title: Amino Labs
+status: active
 subtitle: Empowering the next generation of scientists and innovators
 website: https://amino.bio/
 start-date: 2015

--- a/_startups/BentoLab/BentoLab.md
+++ b/_startups/BentoLab/BentoLab.md
@@ -1,5 +1,6 @@
 ---
 title: Bento Lab
+status: active
 subtitle: The portable DNA analysis lab for scientists, students and all curious minds to engage with genetics and bioengineering.
 website: https://www.bento.bio
 start-date: 2014

--- a/_startups/BillionToOne/BillionToOne.md
+++ b/_startups/BillionToOne/BillionToOne.md
@@ -1,5 +1,6 @@
 ---
 title: Billion to One
+status: active
 subtitle: Prenatal testing for every expecting mother
 website: https://www.billiontoone.com/
 start-date:

--- a/_startups/Biomeme/Biomeme.md
+++ b/_startups/Biomeme/Biomeme.md
@@ -1,5 +1,6 @@
 ---
 title: Biomeme
+status: active
 subtitle:
 website: http://biomeme.com/
 start-date: 2013

--- a/_startups/CellEleven/CellEleven.md
+++ b/_startups/CellEleven/CellEleven.md
@@ -1,6 +1,7 @@
 ---
 draft: false
 title: Cell Eleven
+status: unknown
 subtitle:     Cell Eleven's goal is to make biotech more accessible, by making tools follow five basic principles; open hardware/software, standard parts, modular, and standard IO protocol.
 start-date: 2016
 type-org: Hardware

--- a/_startups/ChaiBio/ChaiBio.md
+++ b/_startups/ChaiBio/ChaiBio.md
@@ -1,5 +1,6 @@
 ---
 title: Chai Bio
+status: active
 subtitle: DNA diagnostics for everyone
 website: https://www.chaibio.com/
 start-date: 2016

--- a/_startups/Chronomed/Chronomed.md
+++ b/_startups/Chronomed/Chronomed.md
@@ -1,5 +1,6 @@
 ---
 title: Chronomed
+status: inactive
 subtitle:
 website:
 start-date: 2016

--- a/_startups/ClearGene/ClearGene.md
+++ b/_startups/ClearGene/ClearGene.md
@@ -1,5 +1,6 @@
 ---
 title: Clear Gene
+status: active
 subtitle: Making Discoveries Count
 website: http://www.cleargene.co/
 start-date: 

--- a/_startups/Combimmune/Combimmune.md
+++ b/_startups/Combimmune/Combimmune.md
@@ -1,5 +1,6 @@
 ---
 title: Combimmune
+status: inactive
 subtitle: Development of rational combinatorial immunotherapies for cancer.
 website: http://www.combimmune.com/
 start-date: 2012

--- a/_startups/ConectorCiencia/ConectorCiencia.md
+++ b/_startups/ConectorCiencia/ConectorCiencia.md
@@ -1,6 +1,7 @@
 ---
 draft: true
 title: Conector Ciência
+status: inactive
 subtitle: We connect Brazilians with the Science of DIYBio / Conectamos os brasileiros com a ciência DIYBio  
 start-date: 2017-11-11
 # end-date: ongoing # 'ongoing' is an invalid value for this field, it needs to be a 'date string'

--- a/_startups/DigiBio/DigiBio.md
+++ b/_startups/DigiBio/DigiBio.md
@@ -1,5 +1,6 @@
 ---
 title: Digi.Bio
+status: active
 subtitle:
 website: http://digi.bio/
 start-date: 2017

--- a/_startups/EcovativeDesign/EcovativeDesign.md
+++ b/_startups/EcovativeDesign/EcovativeDesign.md
@@ -1,5 +1,6 @@
 ---
 title: Ecovative Design
+status: active
 subtitle:
 website: https://www.ecovativedesign.com/
 start-date: 2007

--- a/_startups/EligoBioscience/EligoBioscience.md
+++ b/_startups/EligoBioscience/EligoBioscience.md
@@ -1,5 +1,6 @@
 ---
 title: Eligo Bioscience
+status: active
 subtitle: The MicroBiome Company
 website: http://eligo.bio/
 start-date: 2014

--- a/_startups/FoliaWater/FoliaWater.md
+++ b/_startups/FoliaWater/FoliaWater.md
@@ -1,5 +1,6 @@
 ---
 title: Folia Water
+status: active
 subtitle: The World's First Water Filter For Pennies, Not Dollars.
 website: https://www.foliawater.com/
 start-date: 2016

--- a/_startups/FoliumBiosciences/FoliumBiosciences.md
+++ b/_startups/FoliumBiosciences/FoliumBiosciences.md
@@ -1,5 +1,6 @@
 ---
 title: Folium Biosciences
+status: inactive
 subtitle: 
 website:
 start-date: 2015

--- a/_startups/HyasynthBiologicals/HyasynthBiologicals.md
+++ b/_startups/HyasynthBiologicals/HyasynthBiologicals.md
@@ -1,5 +1,6 @@
 ---
 title: Hyasynth Biologicals
+status: inactive
 subtitle:
 website: http://hyasynthbio.com/
 start-date: 2014

--- a/_startups/InnovativeMedicine/InnovativeMedicine.md
+++ b/_startups/InnovativeMedicine/InnovativeMedicine.md
@@ -1,5 +1,6 @@
 ---
 title: Innovative Medicine
+status: inactive
 subtitle:
 website: https://innovativemedicine.com/
 start-date: 2004

--- a/_startups/Kilobaser/Kilobaser.md
+++ b/_startups/Kilobaser/Kilobaser.md
@@ -1,5 +1,6 @@
 ---
 title: Kilobaser
+status: active
 subtitle: The Nespresso Machine For DNA Synthesis
 website: http://www.kilobaser.com/
 start-date: 2014

--- a/_startups/Microsynbiotix/Microsynbiotix.md
+++ b/_startups/Microsynbiotix/Microsynbiotix.md
@@ -1,5 +1,6 @@
 ---
 title: Microsynbiotix
+status: inactive
 subtitle:
 website: https://www.microsynbiotix.com/
 start-date: 

--- a/_startups/OpenBionics/OpenBionics.md
+++ b/_startups/OpenBionics/OpenBionics.md
@@ -1,5 +1,6 @@
 ---
 title: OpenBionics
+status: active
 subtitle: The Next Generation of Bionics
 website: https://www.openbionics.com/
 start-date: 2014

--- a/_startups/OpenTrons/OpenTrons.md
+++ b/_startups/OpenTrons/OpenTrons.md
@@ -1,5 +1,6 @@
 ---
 title: Open Trons
+status: active
 subtitle: Opentrons makes robots for biologists.
 website: https://opentrons.com/
 start-date: 2014

--- a/_startups/PILI/PILI.md
+++ b/_startups/PILI/PILI.md
@@ -1,5 +1,6 @@
 ---
 title: PILI
+status: active
 subtitle:
 website: http://www.pili.bio/
 start-date: 2014

--- a/_startups/ProspectiveResearch/ProspectiveResearch.md
+++ b/_startups/ProspectiveResearch/ProspectiveResearch.md
@@ -1,5 +1,6 @@
 ---
 title: Prospective Research
+status: inactive
 subtitle: Commercializing The Language Of Bacteria
 website:
 start-date: 

--- a/_startups/Quantgene/Quantgene.md
+++ b/_startups/Quantgene/Quantgene.md
@@ -1,5 +1,6 @@
 ---
 title: Quantgene
+status: active
 subtitle: Making cancer a curable disease through early cancer detection
 website: http://www.quantgene.com/
 start-date: 2016

--- a/_startups/RotterZwam/RotterZwam.md
+++ b/_startups/RotterZwam/RotterZwam.md
@@ -1,5 +1,6 @@
 ---
 title: RotterZwam
+status: active
 subtitle:
 website: https://www.rotterzwam.nl/
 start-date: 2017

--- a/_startups/SE3D/SE3D.md
+++ b/_startups/SE3D/SE3D.md
@@ -1,5 +1,6 @@
 ---
 title: SE3D
+status: unknown
 subtitle:
 website: https://www.se3d.com/
 start-date: 2014

--- a/_startups/TheODIN/TheODIN.md
+++ b/_startups/TheODIN/TheODIN.md
@@ -1,5 +1,6 @@
 ---
 title: The ODIN
+status: active
 subtitle:
 website: http://www.the-odin.com/
 start-date: 2016

--- a/_startups/feles/Feles.md
+++ b/_startups/feles/Feles.md
@@ -1,5 +1,6 @@
 ---
 title: Feles
+status: inactive
 subtitle: Build desktop biolabs for everyone
 website:
 start-date: 2018-07-01


### PR DESCRIPTION
## Summary
Follow-up to the Labs status cleanup, using the same mapping and the full 188-entry directory audit:

| Audit verdict | `status:` value |
|---|---|
| ACTIVE | `active` |
| DEFUNCT | `inactive` |
| STALE / DORMANT / UNKNOWN | `unknown` |

- 114 entries got an explicit `status:` added (previously relying on the auto-derived value from `start-date`/`end-date`, which for many of these no longer matches reality)
- 9 entries already had the correct status and were left alone
- 1 entry (NYC Bio, Networks) had a pre-existing `status: inactive` that conflicted with the audit finding (dormant — no confirmed evidence either way, not confirmed closed) and was corrected to `unknown`

Breakdown by collection: Projects (20), Startups (32), Incubators (9), Groups (30), Networks (11), Events (14), Others (8) = 124 entries total.

No entries were removed or otherwise edited — just the `status:` field.

## Test plan
- [x] Diffed every file — exactly one `status:` line added or changed per entry, nothing else touched
- [x] YAML-parsed all 115 changed front-matter blocks to confirm none broke