### PR TITLE
Default browse to active entries + status badges

### DIFF
--- a/_layouts/entries.html
+++ b/_layouts/entries.html
@@ -36,7 +36,7 @@ layout: default
               <td><h4 class="ui header">Status:</h4></td>
               <td>
                 <div id="status"></div>
-                <div class="ui mini grey text">Showing Active entries by default &mdash; select Inactive/Unknown/Planned above to include them.</div>
+                <div class="ui mini grey text">Showing Active entries by default &mdash; select Inactive or Unknown above to include them.</div>
               </td>
             </tr>
             <tr>

--- a/_layouts/entries.html
+++ b/_layouts/entries.html
@@ -34,7 +34,10 @@ layout: default
           <tbody>
             <tr>
               <td><h4 class="ui header">Status:</h4></td>
-              <td><div id="status"></div></td>
+              <td>
+                <div id="status"></div>
+                <div class="ui mini grey text">Showing Active entries by default &mdash; select Inactive/Unknown/Planned above to include them.</div>
+              </td>
             </tr>
             <tr>
               <td><h4 class="ui header">Collections:</h4></td>

--- a/assets/js/browse_instantsearch.es6
+++ b/assets/js/browse_instantsearch.es6
@@ -4,9 +4,33 @@ const search = instantsearch({
   apiKey: window.site.algolia.apiKey,
   urlSync: true,
   searchParameters: {
-    facetingAfterDistinct: true
+    facetingAfterDistinct: true,
+    // Default view shows active entries only; urlSync restores whatever
+    // status refinement is in the URL (including none) on top of this.
+    disjunctiveFacetsRefinements: {
+      status: ['active']
+    }
   }
 });
+
+// Status -> Semantic UI label color + display text, used by the hit
+// templates below. 'planned' is included because the site's own
+// add-variables-to-files.rb plugin can auto-derive it for entries with
+// a future start-date and no explicit status, even though no entry
+// currently uses it.
+const STATUS_META = {
+  active:   { label: 'Active',   color: 'green' },
+  inactive: { label: 'Inactive', color: 'grey' },
+  unknown:  { label: 'Unknown',  color: 'yellow' },
+  planned:  { label: 'Planned',  color: 'blue' },
+};
+
+function withStatusBadge(item) {
+  const meta = STATUS_META[item.status] || { label: item.status, color: 'grey' };
+  item.statusLabel = meta.label;
+  item.statusBadgeColor = meta.color;
+  return item;
+}
 
 search.addWidget(
   instantsearch.widgets.searchBox({
@@ -101,7 +125,7 @@ const HIT_TEMPLATE = `
           {{start-date}}
           {{/start-date}}
           {{#end-date}} - {{end-date}}{{/end-date}}
-          {{#start-date}} | {{/start-date}}<span data-tooltip="status" data-variation="mini" data-inverted=""><i class="far fa-bolt fa-fw fa-sm" data-fa-transform="down-1"></i></span>{{status}} |
+          {{#start-date}} | {{/start-date}}<span class="ui {{statusBadgeColor}} mini label">{{statusLabel}}</span> |
           {{#country}}
           <span data-tooltip="location" data-variation="mini" data-inverted="">
           <i class="far fa-map-marker-alt fa-fw fa-sm"></i>
@@ -147,6 +171,7 @@ const TABLE_TEMPLATE = `
     <tr>
       <th>Title</th>
       <th>Collection</th>
+      <th>Status</th>
       <th>Type</th>
       <th>Start</th>
       <th>End</th>
@@ -160,6 +185,7 @@ const TABLE_TEMPLATE = `
     <tr>
       <td><a href="{{url}}">{{{ _highlightResult.title.value }}}</a></td>
       <td>{{#project}}Project{{/project}}{{#startup}}Startup{{/startup}}{{#lab}}Lab{{/lab}}{{#incubator}}Incubator{{/incubator}}{{#group}}Group{{/group}}{{#network}}Network{{/network}}{{#event}}Event{{/event}}{{#other}}Other{{/other}}</td>
+      <td><span class="ui {{statusBadgeColor}} mini label">{{statusLabel}}</span></td>
       <td>{{type-org}}</td>
       <td>{{start-date}}</td>
       <td>{{end-date}}</td>
@@ -178,6 +204,9 @@ const gridHits = instantsearch.widgets.hits({
       empty: EMPTY_TEMPLATE,
       item: HIT_TEMPLATE
     },
+    transformData: {
+      item: withStatusBadge
+    },
   });
 
 const tableHits = instantsearch.widgets.hits({
@@ -185,6 +214,15 @@ const tableHits = instantsearch.widgets.hits({
 		templates: {
 			empty: EMPTY_TEMPLATE,
 			allItems: TABLE_TEMPLATE
+		},
+		// transformData.item only fires for a `templates.item` template, so the
+		// table view (which uses `allItems`) needs its own transform over the
+		// hits array to get the same status-badge fields per row.
+		transformData: {
+			allItems: (data) => {
+				data.hits = data.hits.map(withStatusBadge);
+				return data;
+			}
 		},
 	});
 


### PR DESCRIPTION
## Summary
Follow-up to the directory audit/status cleanup (#354) — makes the `status` data actually useful to visitors on the `/browse` page:

1. **Default filter**: browse/search now shows only `status: active` entries by default (via `disjunctiveFacetsRefinements` in `browse_instantsearch.es6`). The existing status `refinementList` filter still works exactly as before, so a visitor can check Inactive / Unknown / Planned to include them — nothing was removed, just the initial state changed. Because `urlSync` is already on, a bookmarked/shared URL with its own status refinement (or none) takes precedence over this default.
2. **Status badges**: replaced the plain-text `{{status}}` in each result card with a colored Semantic UI label — green=active, grey=inactive, yellow=unknown, blue=planned (planned is included for completeness; no entry currently uses it, but the site's own `add-variables-to-files.rb` plugin can auto-derive it for future-dated entries with no explicit status). Same badge added to the table view, which previously didn't show status at all.
3. Added a one-line hint under the Status filter in `entries.html` ("Showing Active entries by default...") so the default isn't silent/surprising.

No `_config.yml` or Algolia index changes were needed — `status` was already in `attributesForFaceting`/`searchableAttributes`, and the existing `#status` refinementList widget/container were already fully wired end to end.

## How to verify
This is client-side JS driven by the **live production Algolia index** using the public search-only key already baked into `_config.yml` (not a Netlify secret) — so the deploy preview for this PR is a real test, not a stub:
- Visit the deploy preview's `/browse` page — it should load already filtered to Active, with the stats count reflecting that.
- Check "Inactive"/"Unknown" in the Status filter — previously-hidden entries should appear with grey/yellow badges.
- Switch to table view — confirm the new Status column renders.

## Test plan
- [x] `node --check` on the modified `.es6` file — syntax valid
- [x] Diffed both files — changes are additive/scoped, no unrelated edits
- [ ] Visual check on the Netlify deploy preview (I can't drive a browser from here — please confirm before merging)