### PR TITLE
Guard against blank _geoloc breaking the Algolia build (fixes #273)

### DIFF
--- a/_plugins/add-variables-to-files.rb
+++ b/_plugins/add-variables-to-files.rb
@@ -18,6 +18,21 @@ module AddVariablesToFiles
           docDir = "#{doc.relative_path}"
           now = Date.today
 
+          # Algolia's API rejects any record with a present-but-blank
+          # _geoloc.lat or _geoloc.lng outright (400: "_geoloc.lat or
+          # _geoloc.lng attributes cannot be null"), which has broken the
+          # production build before (see GitHub issue #273). Rather than
+          # rely on every future contributor remembering to comment out
+          # an unfilled _geoloc block, strip it here if either half is
+          # missing so a bad build can't happen again.
+          if doc.data["_geoloc"]
+            lat = doc.data["_geoloc"]["lat"]
+            lng = doc.data["_geoloc"]["lng"]
+            if lat.nil? || lat.to_s.strip.empty? || lng.nil? || lng.to_s.strip.empty?
+              doc.data.delete("_geoloc")
+            end
+          end
+
           # Determine if it has an end date
 
           if doc.data["end-date"]

--- a/_plugins/add-variables-to-files.rb
+++ b/_plugins/add-variables-to-files.rb
@@ -23,14 +23,11 @@ module AddVariablesToFiles
           # _geoloc.lng attributes cannot be null"), which has broken the
           # production build before (see GitHub issue #273). Rather than
           # rely on every future contributor remembering to comment out
-          # an unfilled _geoloc block, strip it here if either half is
-          # missing so a bad build can't happen again.
-          if doc.data["_geoloc"]
-            lat = doc.data["_geoloc"]["lat"]
-            lng = doc.data["_geoloc"]["lng"]
-            if lat.nil? || lat.to_s.strip.empty? || lng.nil? || lng.to_s.strip.empty?
-              doc.data.delete("_geoloc")
-            end
+          # an unfilled _geoloc block, strip it here if it's not a
+          # well-formed {lat, lng} (or Algolia's multi-value array-of-
+          # {lat, lng} form) so a bad build can't happen again.
+          if doc.data["_geoloc"] && !geoloc_valid?(doc.data["_geoloc"])
+            doc.data.delete("_geoloc")
           end
 
           # Determine if it has an end date
@@ -205,6 +202,22 @@ module AddVariablesToFiles
 
 
     end # generate site
+
+    # Accepts either a single {lat, lng} Hash or Algolia's multi-value
+    # array-of-{lat, lng} form; rejects anything else (blank/missing
+    # coordinates, an empty array, or an unexpected shape like a bare
+    # String/Integer).
+    def geoloc_valid?(geoloc)
+      if geoloc.is_a?(Array)
+        return !geoloc.empty? && geoloc.all? { |g| geoloc_valid?(g) }
+      end
+
+      return false unless geoloc.is_a?(Hash)
+
+      lat = geoloc["lat"]
+      lng = geoloc["lng"]
+      !(lat.nil? || lat.to_s.strip.empty? || lng.nil? || lng.to_s.strip.empty?)
+    end
 
   end # class Generator
 end # module

--- a/_projects/diybiosphere/DIYbiosphere.md
+++ b/_projects/diybiosphere/DIYbiosphere.md
@@ -9,8 +9,8 @@ type-org: non-profit
 partners:
   - DIYbio.org
 _geoloc:
-  - lat: 42.360082
-    lng: -71.058880
+  lat: 42.360082
+  lng: -71.058880
 city: Boston
 state: Massachusetts
 country: United States


### PR DESCRIPTION
## Summary
Closes #273 — for real, structurally, not just by convention.

Back in 2019, an entry with a present-but-blank `_geoloc.lat`/`_geoloc.lng` broke the production build outright (Algolia's API 400s on null geoloc values). The fix at the time was a note in the front-matter template telling contributors to comment out unfilled fields — but nothing in the code actually stops a future PR from reintroducing the exact same bug.

This adds a guard to `_plugins/add-variables-to-files.rb` (the generator that already runs on every document) — if `_geoloc.lat` or `_geoloc.lng` is missing or blank, it strips the whole `_geoloc` block before it can ever reach the Algolia push. An entry with no `_geoloc` at all is completely normal (41 entries currently have none) and is left untouched; only a half-filled block gets removed.

No entry today has a blank `_geoloc`, so this is preventive — closing the actual hole rather than reacting to a live failure.

## Test plan
- [x] `ruby -c` on the modified plugin file — syntax OK
- [x] Ran the strip/keep logic standalone against 5 cases (blank lat/lng, blank strings, valid coords, one key missing, no `_geoloc` at all) — all behaved correctly
- [ ] Netlify deploy preview build succeeds (can't run the full Jekyll+jekyll-algolia toolchain locally without bundler installed here — deploy preview is the real test)