### PR TITLE
Add Mboalab, Hive Biolab, and Nemeton

### DIFF
--- a/_labs/HiveBiolab/HiveBiolab.md
+++ b/_labs/HiveBiolab/HiveBiolab.md
@@ -1,0 +1,30 @@
+---
+title: Hive Biolab
+status: active
+subtitle: Ghana's first community DIYbio lab
+website: https://kumasihive.com/bio-lab
+start-date: 2019
+type-org: community
+city: Kumasi
+state: Ashanti
+country: Ghana
+_geoloc:
+  lat: 6.6885
+  lng: -1.6244
+tags:
+  - Open Bioeconomy
+  - DIYbio
+  - Biotechnology
+  - Africa
+twitter: https://twitter.com/hivebiolab
+facebook: https://www.facebook.com/hivebiolab/
+links:
+  - URL: https://openbioeconomy.org/team/ghana-node/
+    tooltip: Open Bioeconomy Lab - Ghana Node
+---
+
+Hive Biolab, launched in 2019, is Ghana's first community/DIYbio lab, dedicated to the rapid prototyping of ideas in biology and helping students and graduates translate science into enterprising bio-startups. It operates as a node of the Open Bioeconomy Lab, working with the Cambridge-based Open Bioeconomy Lab team to produce enzymes for molecular biology applications and develop early-stage molecular diagnostic prototypes from local materials.
+
+The lab also provides training in synthetic biology, genetic engineering, and recombinant DNA technology to university students, graduates, and Ghanaian academics, and works on alternative solutions in health and disease, agriculture, and waste management for Ghanaian communities. It is based at Kumasi Hive, a broader innovation hub for tech, business, and startup support in Ghana.
+
+*Text adapted from OpenPlant and Open Bioeconomy Lab coverage of Hive Biolab's launch and ongoing work.

--- a/_labs/Mboalab/Mboalab.md
+++ b/_labs/Mboalab/Mboalab.md
@@ -1,0 +1,28 @@
+---
+title: Mboalab
+status: active
+subtitle: DIY open bioeconomy research unit for community education and social innovation
+start-date: 2018
+type-org: community
+address: Mefou-Assi
+city: Yaoundé
+country: Cameroon
+_geoloc:
+  lat: 3.848
+  lng: 11.502
+tags:
+  - Open Bioeconomy
+  - DIYbio
+  - Diagnostics
+  - Africa
+linkedin: https://cm.linkedin.com/company/mboalab
+links:
+  - URL: https://openbioeconomy.org/team/cameroon-node/
+    tooltip: Open Bioeconomy Lab - Cameroon Node
+---
+
+MboaLab is an open and collaborative space in the village of Mefou-Assi, Yaoundé. In Ewondo, "Mboa" means "unique"; in Duala, "village" — MboaLab is a village dedicated to creation, a laboratory for social innovation, community education, collaboration, and mediation at the service of the community.
+
+Established in 2018 with support from the Open Bioeconomy Lab and the Shuttleworth Foundation, MboaLab's aim is to catalyse sustainable local development and improve living conditions through open science. Its work focuses on making biotechnology research and tools more accessible through local production of reagents, scientific research targeting local health issues, internships, and training sessions equipping young local scientists with molecular biology and DIY-biology skills. Notable projects include a locally-manufacturable diagnostic for distinguishing typhoid from paratyphoid fever, developed with Buea University at a reagent cost of under $1 per reaction.
+
+*Text adapted from the Open Bioeconomy Lab's description of their Cameroon node — MboaLab does not currently have an independent working website; its old `.africa` domain has since expired and is now held by an unrelated site.

--- a/_labs/Nemeton/Nemeton.md
+++ b/_labs/Nemeton/Nemeton.md
@@ -1,0 +1,29 @@
+---
+title: Nemeton
+status: active
+subtitle: Biolab Café — democratizing the sciences and techniques of living organisms
+website: https://nemeton.bio
+start-date: 2018
+type-org: community
+address: 11 rue Marx Dormoy
+city: Grenoble
+country: France
+_geoloc:
+  lat: 45.1885
+  lng: 5.7245
+tags:
+  - Biolab
+  - Citizen Science
+  - Ecology
+  - Community
+instagram: https://www.instagram.com/nemeton.bio
+facebook: https://www.facebook.com/nemeton.bio/
+linkedin: https://fr.linkedin.com/company/nemeton-le-biolab-de-grenoble
+email: contact@nemeton.bio
+---
+
+Nemeton is a scientific association founded in 2018 in Grenoble, working to democratize the sciences and techniques of living organisms as tools for ecological transition. In June 2026 it opened the Nemeton Biolab Café at 11 rue Marx Dormoy in the Saint-Bruno neighborhood — a hybrid venue combining a 100% plant-based restaurant and café with a collaborative biology laboratory in the basement, shared by students, artists, and researchers.
+
+Activities include monthly "Soirées du Vivant" (dinner-conferences on biology and ecology), mountain scientific expeditions at Lacs Robert (bioacoustics, environmental DNA), Citeuropass — an Erasmus+ program run across four European countries — and school workshops and science outreach in underserved communities.
+
+*Text adapted from Nemeton's own website and local press coverage of the Biolab Café opening.


### PR DESCRIPTION
## Summary
Adds the 3 confirmed-active, confirmed-reachable community labs from the Global Community Bio Summit research pass:

| Entry | Location | Website |
|---|---|---|
| Mboalab | Yaoundé, Cameroon | No independent site — linked to LinkedIn + Open Bioeconomy Lab's Cameroon node page instead |
| Hive Biolab | Kumasi, Ghana | kumasihive.com/bio-lab |
| Nemeton | Grenoble, France | nemeton.bio |

All three are Open Bioeconomy Lab or similarly well-documented nodes with real, current activity (Nemeton's Biolab Café opened this past June; Hive Biolab and Mboalab are both active Open Bioeconomy Lab nodes with ongoing reagent/diagnostics work).

Holding off on the other 5 candidates from the same research pass (Biomakespace, Biohacking Space Peshawar, Open BioLab Brussels, Xinampa, LABVA) since none currently has a cleanly reachable website — happy to add them once/if a working link turns up.

## Test plan
- [x] YAML-validated all 3 front-matter blocks
- [x] Verified each website/social link resolves as of today
- [x] Description text sourced from each org's own site or independent press/partner coverage, cited in each entry