### PR TITLE
Add missing Global Community Bio Summit editions (4.0-7.0)

### DIFF
--- a/_events/GlobalCommunityBioSummit/GlobalCommunityBioSummit.md
+++ b/_events/GlobalCommunityBioSummit/GlobalCommunityBioSummit.md
@@ -15,20 +15,27 @@ twitter:
 facebook:
 tags:
   - conference
-  -
+  - community biology
 _geoloc:
   lat: 42.360611
   lng: -71.087339
 ---
 
 ## About
-The Community Biotechnology Initiative at the MIT Media Lab is organizes the Global Community Bio Summit. Our goal is to provide a space for the global community of bio-hackers and members of independent and community laboratories to convene, plan, build fellowship, and continue the evolution of our movement. Our programming topics will include: diversity and inclusion, sharing and learning, bio security, enabling technologies, bio art and design, and more. The first event was held in 2017. 
+The Community Biotechnology Initiative at the MIT Media Lab organizes the Global Community Bio Summit (GCBS). Its goal is to provide a space for the global community of bio-hackers and members of independent and community laboratories to convene, plan, build fellowship, and continue the evolution of the movement. Programming topics have included diversity and inclusion, sharing and learning, bio security, enabling technologies, bio art and design, governance, and (starting with the pandemic-era 4.0 edition) responding to COVID-19.
+
+The first edition was held in 2017, and the summit has convened almost every year since, moving to an all-virtual format starting with 4.0 in 2020. A virtual reunion was held in October 2024, at which planning began for a 7.0 edition.
 
 ## Events (past and future)
 
-+ October 11-13, 2019
-+ October 26 -28, 2018 
-+ September 22-24, 2017 
++ Bio Summit 7.0 — planned, virtual (dates not yet announced)
++ Reunion — October 5, 2024 (virtual)
++ Bio Summit 6.0 — 2022
++ Bio Summit 5.0 — November 18-20, 2021
++ Bio Summit 4.0 — October 9-11, 2020 (virtual, shifted from in-person due to COVID-19)
++ Bio Summit 3.0 — October 11-13, 2019
++ Bio Summit 2.0 — October 26-28, 2018
++ Bio Summit 1.0 — September 22-24, 2017
 
 ---
-Text taken from initiative
+Text adapted from the initiative's own website and event listings; exact dates for 6.0 could not be confirmed.


### PR DESCRIPTION
## Summary
The entry only listed the first 3 editions (2017-2019), even though the summit has run almost every year since. Added:

| Edition | Dates | Notes |
|---|---|---|
| 4.0 | Oct 9-11, 2020 | Shifted to all-virtual due to COVID-19 |
| 5.0 | Nov 18-20, 2021 | |
| 6.0 | 2022 | Exact dates weren't confirmable from available sources — noted as such rather than guessed |
| Reunion | Oct 5, 2024 | Virtual |
| 7.0 | — | Still in planning as of the latest info I could find — listed as planned, not claimed as having happened |

Also fixed a grammar typo in the About section ("is organizes" → "organizes") and filled in a previously-blank second tag.

## Test plan
- [x] YAML front matter validated
- [x] Every date cross-checked against at least one independent source (MIT Media Lab event pages, biosummit.org, press coverage) beyond the summit's own site