### PR TITLE
Fix Twitter->X icon, Basecamp's wrong icon, add Instagram to templates

### DIFF
--- a/_includes/entry/links-icons.html
+++ b/_includes/entry/links-icons.html
@@ -113,8 +113,12 @@ ADDING A NEW
 
     {% if page.twitter %}
     <a class="noelink" href="{{ page.twitter }}" target="_blank">
-      <span data-tooltip="Twitter" data-variation="mini" data-inverted="">
-        <i class="fab fa-twitter"></i>
+      <span data-tooltip="X (Twitter)" data-variation="mini" data-inverted="">
+        <!-- Inline SVG rather than a fontawesome-all.js icon class: the vendored
+             FontAwesome kit predates the 2023 rebrand and has no X glyph, and
+             this repo's kit is old enough (Pro 5.0.4) that swapping it wholesale
+             risks breaking other icons already in use. Official X logo path. -->
+        <svg viewBox="0 0 24 24" width="1em" height="1em" fill="currentColor" style="vertical-align: -0.125em;" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
       </span>
     </a>
     {% endif %}
@@ -178,7 +182,7 @@ ADDING A NEW
     {% if page.basecamp %}
     <a class="noelink" href="{{ page.basecamp }}" target="_blank">
       <span data-tooltip="Basecamp" data-variation="mini" data-inverted="">
-        <i class="fab fa-twitter"></i>
+        <i class="fas fa-tasks"></i>
       </span>
     </a>
     {% endif %}

--- a/docs/CompleteTemplate.md
+++ b/docs/CompleteTemplate.md
@@ -28,8 +28,9 @@ _geoloc: # Geolocation coordinates for mapping
 #LINKS. Check the Writing Guide for all the brand icons available
 website: # URL to main external website
 email: # email
-twitter: # Twitter URL
+twitter: # Twitter/X URL
 facebook: # Facebook URL
+instagram: # Instagram URL
 links:
   - URL: # URL to external link
     tooltip: # when mouse hovers, what the pop over tool tip will say

--- a/docs/EntryTemplate.md
+++ b/docs/EntryTemplate.md
@@ -7,8 +7,9 @@ type-org: #REPLACE_with_type_of_legal_or_social_organization:_'community',_'comp
 address: #REPLACE_with_street_name_and_number_in_english
 city: #REPLACE_with_city_name_in_english
 country: #REPLACE_with_country_name_in_english
-twitter: #REPLACE_with_twitter_URL
+twitter: #REPLACE_with_twitter/X_URL
 facebook: #REPLACE_with_facebook_URL
+instagram: #REPLACE_with_instagram_URL
 tags:
   - #REPLACE_with_a_tag
   - #REPLACE_with_more_tags

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -67,8 +67,9 @@ _geoloc: # Geolocation coordinates for mapping
 #LINKS. Check the Writing Guide for all the brand icons available
 website: # URL to main external website
 email: # email
-twitter: # Twitter URL
+twitter: # Twitter/X URL
 facebook: # Facebook URL
+instagram: # Instagram URL
 links:
   - URL: # URL to external link
     tooltip: # when mouse hovers, what the pop over tool tip will say


### PR DESCRIPTION
## Summary
Addresses #360 — scoped to what's safely fixable without touching the vendored FontAwesome kit itself.

- **Twitter → X**: replaced the old bird icon with an inline SVG of the official X logo (self-contained, not dependent on \`fontawesome-all.js\`), and updated the tooltip to "X (Twitter)". Deliberately kept the \`twitter:\` front-matter key as-is — 131 entries use it, and migrating the key is a separate, bigger decision from just fixing the visible icon.
- **Basecamp**: was also rendering the Twitter bird (copy-paste leftover, unrelated to the rebrand) — now uses \`fa-tasks\`. No entry currently sets \`basecamp:\`, so this was invisible until now, but would've been wrong the moment someone added one.
- **Instagram**: added to \`docs/EntryTemplate.md\` and \`docs/CompleteTemplate.md\` (what new contributors copy from), plus \`docs/docs.md\`'s embedded schema reference — found while checking, it duplicates the same field list and had the identical gap. The field itself already works fine (21 entries use it); it was just never templated.

Why not fix the FontAwesome kit itself: it's Pro 5.0.4 (~2018), and swapping it for a newer bundle risks breaking other icons already in use across the site (would need to verify nothing else in use is Pro-exclusive first). An inline SVG for just the one icon that's actually broken avoids that risk entirely.

## Test plan
- [x] Verified \`fa-tasks\` exists in the current vendored bundle before using it
- [x] X logo SVG path cross-checked against the officially documented path
- [ ] Deploy preview visual check (I can't render Liquid/inline SVG output myself — please confirm the X icon and Basecamp icon look right before merging)