### PR TITLE
Fix mission statement wording and broken [DIYbio.org] link

### DIFF
--- a/_references.md
+++ b/_references.md
@@ -1,7 +1,7 @@
 
 [Avocado Lab]: /docs/tutorials/AvocadoLab/
 [DIYbiosphere]: /projects/diybiosphere/
-[DIYbio.org]: /networks/diybio.org/
+[DIYbio.org]: /networks/diybio-org/
 [Genspace]: /labs/genspace/
 [Biotech Without Borders]: /labs/biotechwithoutborders/
 [BwoB]: /labs/biotechwithoutborders/

--- a/about/diybio-org.md
+++ b/about/diybio-org.md
@@ -3,7 +3,7 @@ layout: page
 title: About DIYbio.org
 ---
 
-DIYbio.org is a 501(c)(3) nonprofit dedicated to making biology an accessible pursuit for citizen scientists, amateur biologists, and DIY biological engineers who value openness and safety. That means building mechanisms for amateurs to grow their knowledge and skills, access to a community of experts, a code of ethics, responsible oversight, and leadership on the issues that are unique to doing biology outside of traditional professional settings.
+DIYbio.org is a 501(c)(3) nonprofit founded in 2008 with the mission of establishing a vibrant, productive and safe community of DIY biologists. Central to that mission is the belief that biotechnology, and greater public understanding about it, has the potential to benefit everyone. That means building mechanisms for amateurs to grow their knowledge and skills, access to a community of experts, a code of ethics, responsible oversight, and leadership on the issues that are unique to doing biology outside of traditional professional settings.
 
 [DIYbiosphere] is DIYbio.org's current, active project. This page is about the organization behind it.
 


### PR DESCRIPTION
## Summary
Two fixes found while checking where DIYbio.org is described across the site:

1. **Wrong mission statement**: \`about/diybio-org.md\` quoted the org's superseded 2008-era WordPress \`/about-2/\` phrasing. The correct, current one is already on the directory entry (\`_networks/DIYbio.org/\`) and matches the live diybio.org homepage itself.
2. **Broken link**: \`_references.md\`'s \`[DIYbio.org]\` reference pointed at \`/networks/diybio.org/\`, which 404s — the real URL is \`/networks/diybio-org/\` (hyphen, not a dot). This was silently broken on every page using that reference: \`_projects/diybiosphere/DIYbiosphere.md\`, \`about/community.md\`, \`about/support-us.md\`, \`docs/basics/design.md\`.

## Test plan
- [x] Confirmed \`/networks/diybio-org/\` returns 200 and \`/networks/diybio.org/\` returns 404 on the live site
- [x] Confirmed the corrected mission text matches both the existing directory entry and the current live diybio.org homepage