### PR TITLE
Clean up DIYbiosphere project entry, link to real history

### DIFF
--- a/_projects/diybiosphere/DIYbiosphere.md
+++ b/_projects/diybiosphere/DIYbiosphere.md
@@ -6,7 +6,7 @@ subtitle: Connecting DIYbio Worldwide
 website: http://sphere.diybio.org/
 start-date: 2016
 type-org: non-profit
-partners:
+hosts:
   - DIYbio.org
 _geoloc:
   lat: 42.360082
@@ -23,17 +23,15 @@ tags:
 
 
 # About
-The DIYbiosphere is an open-source project to connect Do-it-Yourself Biology (DIYbio) initiatives from all over the world. It works similar to a wiki in which entries for each initiative are created. They easily editable through the GitHub interface
-
-The DIYbiosphere is an open-source project to collect Do-It-Yourself Biology (DIYbio) initiatives from all over the world. One of it's main purpose is to replace the list of DIYbio labs indexed in the [Local] section in the [DIYbio.org] website.
+The DIYbiosphere is an open-source project to connect Do-It-Yourself Biology (DIYbio) initiatives from all over the world. It works similar to a wiki, in which an entry is created for each initiative; entries are easily editable through the GitHub interface. One of its main purposes is to replace the previous list of DIYbio labs on the [DIYbio.org] website.
 
 ### To contribute
 Edit or add your own DIYbio initiative to the repository.
 
 
 # Mission
-The goal is to have a common space where the DIYbio community can share about who and where they are and what they are doing. We believe that a centralized directory could benefit the DIYbio community by increasing visibility to projects, organizations and events. We hope that by connecting people and ideas, they may inspire, learn, and collaborate with each other. Additionally, the project can also serve as a reference point for DIYbio supporters and followers, including journalists, scholars, governmental agencies, and more.
+The goal is to have a common space where the DIYbio community can share who and where they are and what they are doing. We believe that a centralized directory can benefit the DIYbio community by increasing visibility for projects, organizations, and events. We hope that by connecting people and ideas, they may inspire, learn, and collaborate with each other. The project can also serve as a reference point for DIYbio supporters and followers, including journalists, scholars, governmental agencies, and more.
 
 
 # History
-The project was proposed as an alternative mode to gather, access, and share information about DIYbio initiatives in a way that positively contributes useful resources back to the community.
+DIYbiosphere's original vision, how it replaced DIYbio.org's old `/local` page, and its GitHub-based approach are told on the [DIYbiosphere project page][diybiosphere project page].


### PR DESCRIPTION
## Summary
Found while checking where the org/project are described (per the earlier mission-statement fix):

- Merged two near-duplicate "About" paragraphs into one.
- Fixed a grammar error ("They easily editable" → "entries are easily editable").
- Removed a broken \`[Local]\` reference link — undefined in \`_references.md\`, was silently rendering as literal plain text \`[Local]\` instead of a link.
- Replaced the thin "History" stub ("The project was proposed as an alternative mode...") with a pointer to the actual detailed history already on the About page — original vision credited to Gabriela Sanchez, the 2018 launch story, the Jenny Reardon quote — rather than a vague duplicate.
- \`partners:\` → \`hosts:\` for DIYbio.org, matching what that field is actually for per the docs ("the space or organization behind the initiative") rather than a collaborator relationship.

## Test plan
- [x] YAML front matter validated
- [x] Checked for dangling reference-style links — none