### PR TITLE
Point homepage carousel CTA at adding an entry

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,11 +11,11 @@ layout: landing
         <div class="center">
           <div class="ui basic fluid blurring segment">
           <h1 class="ui header"><div class="ui big inverted header black">DIYbiosphere</div></h1>
-          <div class="ui header black">An open source project to connect DIYbio initiatives worlwide. Search, browse, update, or add an initiative!</div>
+          <div class="ui header black">An open source project to connect DIYbio initiatives worldwide. Search, browse, update, or add an initiative!</div>
           <div class="ui header black">
-            To contribute all you need is a <a href="https://www.google.ch/url?sa=t&rct=j&q=&esrc=s&source=web&cd=1&cad=rja&uact=8&ved=0ahUKEwig3Zb8wMTVAhUPmbQKHU31DbwQFggoMAA&url=https%3A%2F%2Fgithub.com%2Fjoin&usg=AFQjCNF6nezHQWX1hKwEFQVYRrUheS9_Ig">GitHub account!</a>
+            To contribute all you need is a <a href="https://github.com/join">GitHub account!</a>
           </div>
-          <a href="/projects/diybiosphere/"><button class="ui green big button">LEARN MORE</button></a>
+          <a href="/docs/tutorials/add-entry/"><button class="ui green big button">ADD YOUR ENTRY</button></a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
The homepage carousel's first slide already promises "Search, browse, update, or add an initiative!" in its subtitle, but the button underneath said "LEARN MORE" and linked to \`/projects/diybiosphere/\` — the DIYbiosphere project's own directory entry, which isn't an actionable next step for a visitor who wants to add their own initiative.

- Button now reads **"ADD YOUR ENTRY"** and links to \`/docs/tutorials/add-entry/\`, which now has the quick-create buttons (from the earlier PR #359) for jumping straight into a pre-filled new file.
- Fixed "worlwide" → "worldwide" in the same block.
- Fixed the GitHub signup link, which was a hardcoded Google search-result redirect URL rather than a direct link to github.com/join.

## Test plan
- [x] Diffed the file — only this one carousel slide's text/links changed