### PR TITLE
Normalize country names across all collections

### DIFF
--- a/_events/PoreCamp/PoreCampVancouver.md
+++ b/_events/PoreCamp/PoreCampVancouver.md
@@ -5,8 +5,8 @@ subtitle: A Training Bootcamp Based On The Oxford Nanopore MinION
 website: http://porecamp.github.io/
 start-date: 2015
 type-org:
-city:
-country: USA
+city: Vancouver
+country: Canada
 twitter:
 facebook:
 tags:

--- a/_groups/ManilaBiopunk/ManilaBiopunk.md
+++ b/_groups/ManilaBiopunk/ManilaBiopunk.md
@@ -8,7 +8,7 @@ hosts: '[Tsinelas Labs](https://wiki.hackerspaces.org/Tsinelas_Labs)'
 address: Teodoro Gener
 city: Quezon City
 state: Metro Manila
-country: Phillipines
+country: Philippines
 _geoloc:
   lat: 14.628067
   lng: 121.036380

--- a/_labs/BioBlaze/BioBlaze.md
+++ b/_labs/BioBlaze/BioBlaze.md
@@ -9,7 +9,7 @@ address: "1800 W Hawthorne Lane Unit L2"
 postcode: 60185
 city: West Chicago
 state: Illinois
-country: USA
+country: United States
 twitter: 
 facebook: https://www.facebook.com/BioBlazeLab
 meetup: https://www.meetup.com/BioBlaze-Community-Bio-Lab/

--- a/_labs/BioHackPhilly/BioHackPhilly.md
+++ b/_labs/BioHackPhilly/BioHackPhilly.md
@@ -12,7 +12,7 @@ directions: Virtual until the pandemic is over.
 postcode: 19106
 city: Philadelphia
 state: PA
-country: USA
+country: United States
 _geoloc:
   lat: 39.94507369000069
   lng: -75.14264255185073

--- a/_labs/Bugss/Bugss.md
+++ b/_labs/Bugss/Bugss.md
@@ -12,7 +12,7 @@ directions: Located in the King, Cork, and Seal building off of the smaller gate
 postcode: 21224
 city: Baltimore
 state: MD
-country: USA
+country: United States
 _geoloc:
   lat: 39.294383
   lng: -76.562254

--- a/_labs/ChiTownBio/ChiTownBio.md
+++ b/_labs/ChiTownBio/ChiTownBio.md
@@ -9,7 +9,7 @@ hosts:
 type-org: Lab
 city: Chicago
 state: Illinois
-country: USA
+country: United States
 _geoloc:
   lat: 41.878114
   lng: -87.629798

--- a/_labs/Genspace/Genspace.md
+++ b/_labs/Genspace/Genspace.md
@@ -15,7 +15,7 @@ directions: Room #108 (Genspace)
 postcode: 11232
 city: Brooklyn
 state: NY
-country: USA
+country: United States
 _geoloc:
   lat: 40.656802
   lng: -74.002649

--- a/_labs/Incubatorartlab/INCUBATORartlab.md
+++ b/_labs/Incubatorartlab/INCUBATORartlab.md
@@ -14,7 +14,7 @@ directions:
 postcode: N9E1E4
 city: Windsor
 state: Ontario
-country: CANADA
+country: Canada
 _geoloc:
   lat: 42.317627
   lng:  -83.038150

--- a/_labs/Scihouse/Scihouse.md
+++ b/_labs/Scihouse/Scihouse.md
@@ -11,7 +11,7 @@ directions:
 postcode: 46615
 city: South Bend
 state: Indiana
-country: USA
+country: United States
 _geoloc:
   lat: 41.67281164363795
   lng: -86.20607662155541

--- a/_labs/TurbiniaBioLab/turbiniabiolab.md
+++ b/_labs/TurbiniaBioLab/turbiniabiolab.md
@@ -11,7 +11,8 @@ start-date: 2018-09-14
 type-org: Citizen
 postcode: NE5
 city: Newcastle
-country: England
+state: England
+country: United Kingdom
 _geoloc:
   lat: -1.61695
   lng: 54.965791 

--- a/_others/TwistBioscience/TwistBioscience.md
+++ b/_others/TwistBioscience/TwistBioscience.md
@@ -12,7 +12,7 @@ directions:
 postcode: 94080
 city: South San Francisco
 state: CA
-country: USA
+country: United States
 _geoloc:
   lat: 37.659631955052085
   lng: -122.39889036851447

--- a/_others/biorender/biorender.md
+++ b/_others/biorender/biorender.md
@@ -11,7 +11,7 @@ address: 639 Queen Street West
 postcode: M5V 2B7
 city: Toronto
 state: Ontario
-country: Candada
+country: Canada
 _geoloc:
   lat: 43.64729252657655
   lng: -79.40331433696059

--- a/_others/fusionbiotec/FusionBiotec.md
+++ b/_others/fusionbiotec/FusionBiotec.md
@@ -14,7 +14,7 @@ directions: Suite 400
 postcode: 92866
 city: Orange
 state: CA
-country: USA
+country: United States
 _geoloc:
   lat: 33.787083908628695
   lng: -117.85716430707583

--- a/_others/ginkgoBioworks/ginkgobioworks.md
+++ b/_others/ginkgoBioworks/ginkgobioworks.md
@@ -10,7 +10,7 @@ address: 27 Drydock Ave 8th Floor,
 postcode: 02210
 city: Boston
 state: MA
-country: USA
+country: United States
 _geoloc:
   lat: 42.34457463701391
   lng: -71.02792682033841

--- a/_projects/BioArtBot/BioArtBot.md
+++ b/_projects/BioArtBot/BioArtBot.md
@@ -14,7 +14,7 @@ directions: Enter and walk all the way through the door, then turn right to get 
 postcode: 94609
 city: Oakland
 state: CA
-country: USA
+country: United States
 _geoloc:
   lat: 37.835173
   lng: -122.264162

--- a/_projects/GenespaceOptogenetics/GenspacesOptogeneticsCommunityProject.md
+++ b/_projects/GenespaceOptogenetics/GenspacesOptogeneticsCommunityProject.md
@@ -12,7 +12,7 @@ directions: Room #108 (Genspace)
 postcode: 11232
 city: Brooklyn
 state: NY
-country: USA
+country: United States
 _geoloc:
   lat: 40.656802
   lng: -74.002649

--- a/_projects/Genspace/GenspacesOpenPlantCommunityProject.md
+++ b/_projects/Genspace/GenspacesOpenPlantCommunityProject.md
@@ -12,7 +12,7 @@ directions: Room #108 (Genspace)
 postcode: 11232
 city: Brooklyn
 state: NY
-country: USA
+country: United States
 _geoloc:
   lat: 40.656802
   lng: -74.002649

--- a/_startups/BentoLab/BentoLab.md
+++ b/_startups/BentoLab/BentoLab.md
@@ -7,7 +7,7 @@ start-date: 2014
 type-org: company
 address: Corner of Keeton's and Collett Road, 3Space, Bermondsey, SE16 4EE
 city: London
-country: UK
+country: United Kingdom
 twitter: https://www.twitter.com/theBentoLab
 facebook: https://www.facebook.com/theBentoLab
 tags:

--- a/_startups/DigiBio/DigiBio.md
+++ b/_startups/DigiBio/DigiBio.md
@@ -6,7 +6,7 @@ website: http://digi.bio/
 start-date: 2017
 type-org: Company/Start-up
 city: Amsterdam
-country: The Netherlands
+country: Netherlands
 twitter: https://twitter.com/digi_bio
 facebook: https://www.facebook.com/digi.bio.dmf/
 tags:


### PR DESCRIPTION
## Summary
The browse filter's country facet was fragmenting the same country into multiple entries — e.g. "United States" (73) and "USA" (13) showing as separate filter checkboxes. This affects all 8 collections, not just Labs where it was first noticed.

Fixed:
| Variant | Normalized to | Count |
|---|---|---|
| USA | United States | 12 |
| UK | United Kingdom | 1 |
| England | United Kingdom (region moved to new \`state: England\`) | 1 |
| The Netherlands | Netherlands | 1 |
| Candada (typo) | Canada | 1 |
| CANADA (case) | Canada | 1 |
| Phillipines (typo) | Philippines | 1 |

One real find along the way: \`PoreCampVancouver.md\` had \`country: USA\` with a blank city — but it's a real 2018 event hosted at UBC in Vancouver, Canada. Fixed to \`city: Vancouver, country: Canada\` rather than folding it into the USA→United States relabel.

Left 3 entries with a genuinely blank \`country:\` field alone — that's missing data, a different problem from naming inconsistency.

## Test plan
- [x] YAML-validated all 19 changed files
- [x] Verified the PoreCamp Vancouver / UBC / Canada facts via web search before correcting (not just relabeling)
- [x] Re-ran the full country-value tally after the fix — confirms no more fragmented duplicates