### PR TITLE
Fix stale/broken carousel promotion links

### DIFF
--- a/_labs/BiohackUIO/BiohackUIO.md
+++ b/_labs/BiohackUIO/BiohackUIO.md
@@ -57,7 +57,7 @@ tags:
 promotions:
   - text: Hands-on microbiology course series—private certification and lab work.
     button: Learn More
-    URL: https://biohackuio.com/services
+    URL: https://biohackuio.com/servicios-biohack/
     image: https://biohackuio.com/wp-content/uploads/2024/09/3.png
 ---
 

--- a/_projects/BioArtBot/BioArtBot.md
+++ b/_projects/BioArtBot/BioArtBot.md
@@ -34,7 +34,7 @@ links:
 promotions:
   - button: Join us!
     text: We meet once a week to talk about how to make BioArtBot even better!
-    URL: https://www.meetup.com/Counter-Culture-Labs/events/chcjfsyccfbfb/
+    URL: https://www.meetup.com/Counter-Culture-Labs/
 ---
 
 BioArtBot is a project run out of Counter Culture Labs, a community science lab in Oakland, California. Our goal is to help more people do - and have fun with - science!

--- a/_projects/GenespaceOptogenetics/GenspacesOptogeneticsCommunityProject.md
+++ b/_projects/GenespaceOptogenetics/GenspacesOptogeneticsCommunityProject.md
@@ -24,11 +24,6 @@ website: https://www.genspace.org/community-projects
 links:
 - URL: https://www.genspace.org/community-projects
   tooltip: homepage
-promotions:
-  - button: Join Genspace's Optogenetics Community Project!
-    text: Learn how to make multi-colored E. coli
-    URL: https://forms.gle/h5nuy8CwgQ7Mfy187
-    image:
 ---
 
 ### OPTOGENETICS

--- a/_projects/Genspace/GenspacesOpenPlantCommunityProject.md
+++ b/_projects/Genspace/GenspacesOpenPlantCommunityProject.md
@@ -1,7 +1,7 @@
 ---
 draft: true
 title: Genspace's Open Plant Community Project
-status: unknown
+status: active
 hosts:
   - DIYbiosphere
 partners:
@@ -30,14 +30,14 @@ links:
 promotions:
   - button: Join Genspace NYC's Open Plant Project!
     text: Want to learn about gene-editing and plant biology?
-    URL: https://forms.gle/h5nuy8CwgQ7Mfy187
+    URL: https://airtable.com/appOiq4a6LNX7HiQW/pag9Odc96o6aeLW6S/form
     image:
 ---
 
-### OPTOGENETICS
+### OPEN PLANT
 
-Optogenetics is a genetic tool to make cells responsive to light. In some cases it has been used to heal blindness, and in others it has been used to manipulate and understand animal behavior by switching on and off neurons in the brain. In synthetic biology, optogenetics is increasingly used to induce expression of desired genes in bacteria and yeast. Optogenetic systems are easy to assemble and control within cell cultures.
+The Open Plant Collaboration explores plant biology and gene-editing using the liverwort *Marchantia polymorpha*, a model organism for plant synthetic biology, to generate complex proteins.
 
 **Project Description:**
 
-Group members will start exploring by constructing optogenetic systems that display colors as outputs. Once we learn the system we can harness optogenetics to control gene expression in 2-D using different combinations of red, green, and blue light. Some potential results might be bacterial photographs, patterned biomaterials, and inducible control of useful enzymes like Taq polymerase. The project will provide a fantastic learning experience and an introduction to cutting edge synthetic biology techniques for controlling living systems.
+Group members learn plant tissue culture and genetic engineering techniques, applying them to liverworts as an accessible model system for exploring how plants can be engineered to produce useful compounds. The project is part of Genspace's ongoing slate of community projects, open to members interested in plant biology, gene-editing, and citizen science.


### PR DESCRIPTION
## Summary
Started from the BioArtBot report (stale 2021 Meetup event link) and audited every entry with a carousel-eligible \`promotions:\` block (9 total, has \`promotion.image\` or a \`header.*\` file). Found 4 problems:

| Entry | Problem | Fix |
|---|---|---|
| BioArtBot | Linked to a canceled 2021 Meetup event | Now links to the evergreen Meetup group page (already used elsewhere in the same file) |
| BiohackUIO | Linked to \`/services\` — 404, wrong path (site is Spanish) | Fixed to the real page, \`/servicios-biohack/\` |
| Genspace Optogenetics | Advertised joining a project that's actually discontinued (already \`status: inactive\`; not listed on Genspace's own current projects page), via a Google Form that turned out to be Genspace's generic membership application, unrelated to Optogenetics | Removed the promotions block — stop advertising a dead project on the homepage |
| Genspace Open Plant | Same wrong generic membership-form link | Fixed to the real project-specific Airtable join form, confirmed via Genspace's current projects page |

Bigger bug found along the way: the **Open Plant entry's entire body text was a copy-paste of the Optogenetics project** — still headed "### OPTOGENETICS," describing light-responsive genes, nothing about plants at all. Replaced with real content about the liverwort *Marchantia polymorpha* project (sourced from Genspace's own current projects page), and updated \`status: unknown\` → \`active\` given that page confirms it's ongoing.

The other 5 carousel-eligible entries (Bugss, Hackuarium, Genspace classes, BiohackUIO's image, KombuchaGenomics) were checked and are fine — no changes.

## Test plan
- [x] YAML-validated all 4 changed files
- [x] Verified every replacement URL resolves (200) before using it
- [x] Confirmed the Optogenetics/Open Plant mix-up via Genspace's own current community-projects page, not just guessing