### PR TITLE
Remove bogus DIYbiosphere hosts references (20 entries)

### DIFF
--- a/_labs/BioHackPhilly/BioHackPhilly.md
+++ b/_labs/BioHackPhilly/BioHackPhilly.md
@@ -4,8 +4,6 @@ title: BioHackPhilly
 status: unknown
 subtitle: Synthetic Biology is the future of food, fuel, materials, and medicine. And we are here to teach you the basics.
 start-date: 2020
-hosts:
-  - DIYbiosphere
 type-org: Community Lab
 address:
 directions: Virtual until the pandemic is over.

--- a/_labs/Bugss/Bugss.md
+++ b/_labs/Bugss/Bugss.md
@@ -4,8 +4,6 @@ title: Baltimore Underground Science Space (BUGSS)
 status: active
 subtitle: A place for creative biology
 start-date: 2012
-hosts:
-  - DIYbiosphere
 type-org: Lab
 address: 101 N Haven St, Suite 105
 directions: Located in the King, Cork, and Seal building off of the smaller gated parking lot at the north end of the building.

--- a/_labs/ChiTownBio/ChiTownBio.md
+++ b/_labs/ChiTownBio/ChiTownBio.md
@@ -4,8 +4,6 @@ title: ChiTownBio
 status: active
 subtitle: Chicago's first community biolab
 start-date: 2017
-hosts:
-  - DIYbiosphere
 type-org: Lab
 city: Chicago
 state: Illinois

--- a/_labs/DIYbioToronto/DIYbioToronto.md
+++ b/_labs/DIYbioToronto/DIYbioToronto.md
@@ -4,8 +4,6 @@ title: DIYbio Toronto
 status: active
 subtitle: Toronto's Bio-Enthusiast group. Everyone's welcome!
 start-date: 2013
-hosts:
-  - DIYbiosphere # Exact `title: `of DIYbiosphere
 partners:
   - '[Hacklab TO](https://hacklab.to/)]'
 type-org: Lab #community

--- a/_labs/Incubatorartlab/INCUBATORartlab.md
+++ b/_labs/Incubatorartlab/INCUBATORartlab.md
@@ -4,8 +4,6 @@ title: INCUBATOR art lab
 status: active
 subtitle: Hybrid Labratory at the Intersection of Art, Science and Ecology
 start-date: 2009
-hosts:
-  - DIYbiosphere
 partners:
   - '[University of Windsor]()'
 type-org: Lab

--- a/_labs/Scihouse/Scihouse.md
+++ b/_labs/Scihouse/Scihouse.md
@@ -3,8 +3,6 @@ draft: true
 title: Scihouse
 subtitle: Moving biotechnology forward for the common good
 status: unknown
-hosts:
-  - DIYbiosphere
 type-org:
 address:  2920 E Jefferson Blvd
 directions:

--- a/_labs/diybioMelbourne/DIYbioMelbourne.md
+++ b/_labs/diybioMelbourne/DIYbioMelbourne.md
@@ -2,8 +2,6 @@
 draft: true
 title: DIYbio Melbourne
 status: active
-hosts:
-  - DIYbiosphere
 city: Melbourne
 country: Australia
 meetup: https://www.meetup.com/DIYbio-Melbourne/

--- a/_networks/Degenics/Degenics.md
+++ b/_networks/Degenics/Degenics.md
@@ -4,8 +4,6 @@ title: Degenics
 status: inactive
 subtitle: An anonymous, decentralized marketplace for personal genetic testing - built on the Polkadot blockchain.
 start-date: 2020
-hosts:
-  - DIYbiosphere
 partners:
   - '[Blocksphere](http://blocksphere.id)'
   - '[Kilt.io](http://kilt.io)'

--- a/_networks/JOGL/JOGL.md
+++ b/_networks/JOGL/JOGL.md
@@ -4,8 +4,6 @@ title: Just One Giant Lab (JOGL.io)
 status: active
 subtitle:
 start-date: 2018
-hosts:
-  - DIYbiosphere
 partners:
 type-org: Other
 address: 8 bis Rue Charles V, 75004

--- a/_networks/Reclone/reclone.md
+++ b/_networks/Reclone/reclone.md
@@ -4,8 +4,6 @@ title: Reclone
 subtitle: Reagent Collaboration Network
 status: active
 start-date: 2021
-hosts:
-  - DIYbiosphere
 type-org: Network
 tags:
   - Reagents

--- a/_others/MaraRenewables/MaraRenewables.md
+++ b/_others/MaraRenewables/MaraRenewables.md
@@ -4,8 +4,6 @@ title: Mara Renewables
 status: active
 subtitle:
 start-date: 2006
-hosts:
-  - DIYbiosphere
 type-org: Other
 address: 101A Research Drive,
 directions:

--- a/_others/TwistBioscience/TwistBioscience.md
+++ b/_others/TwistBioscience/TwistBioscience.md
@@ -4,8 +4,6 @@ title: Twist Bioscience
 subtitle: DNA Production
 status: active
 start-date: 2021
-hosts:
-  - DIYbiosphere
 type-org:
 address: 681 Gateway Blvd
 directions:

--- a/_others/biorender/biorender.md
+++ b/_others/biorender/biorender.md
@@ -4,8 +4,6 @@ title: Biorender
 subtitle: Create Professional Science Figures in Minutes
 status: active
 start-date: 2021
-hosts:
-  - DIYbiosphere
 type-org:
 address: 639 Queen Street West
 postcode: M5V 2B7

--- a/_others/fusionbiotec/FusionBiotec.md
+++ b/_others/fusionbiotec/FusionBiotec.md
@@ -4,8 +4,6 @@ title: Fusion Biotec
 status: inactive
 subtitle:
 start-date: 2016
-hosts:
-  - DIYbiosphere
 partners:
   -
 type-org: Research and development

--- a/_others/ginkgoBioworks/ginkgobioworks.md
+++ b/_others/ginkgoBioworks/ginkgobioworks.md
@@ -3,8 +3,6 @@ title: Ginkgo Bioworks
 status: active
 subtitle: The organism company.
 start-date: 2009
-hosts:
-  - DIYbiosphere
 type-org: Other
 address: 27 Drydock Ave 8th Floor,
 postcode: 02210

--- a/_others/ibiology/ibiology.md
+++ b/_others/ibiology/ibiology.md
@@ -3,8 +3,6 @@ draft: true
 title: iBiology
 subtitle: Bringing the World's Best Biology to You
 status: active
-hosts:
-  - DIYbiosphere
 type-org: Eduction
 tags:
   - educational

--- a/_projects/ATGstart/atgstart.md
+++ b/_projects/ATGstart/atgstart.md
@@ -2,8 +2,6 @@
 draft: true
 title: ATGStart
 status: active
-hosts:
-  - DIYbiosphere
 type-org: news
 address:
 directions:

--- a/_projects/BioArtBot/BioArtBot.md
+++ b/_projects/BioArtBot/BioArtBot.md
@@ -4,8 +4,6 @@ title: BioArtBot
 status: unknown
 subtitle: Make BioArt with Robots!
 start-date: 2019
-hosts:
-  - DIYbiosphere
 partners:
   - '[Counter Culture Labs]()'
 type-org: Project

--- a/_projects/GenespaceOptogenetics/GenspacesOptogeneticsCommunityProject.md
+++ b/_projects/GenespaceOptogenetics/GenspacesOptogeneticsCommunityProject.md
@@ -3,9 +3,7 @@ draft: true
 title: Genspace's Optogenetics Community Project
 status: inactive
 hosts:
-  - DIYbiosphere
-partners:
-  - '[Genspace]()'
+  - Genspace
 type-org: Project
 address: 132 32nd Street, ,  
 directions: Room #108 (Genspace)

--- a/_projects/Genspace/GenspacesOpenPlantCommunityProject.md
+++ b/_projects/Genspace/GenspacesOpenPlantCommunityProject.md
@@ -3,9 +3,7 @@ draft: true
 title: Genspace's Open Plant Community Project
 status: active
 hosts:
-  - DIYbiosphere
-partners:
-  - '[Genspace]()'
+  - Genspace
 type-org: Project
 address: 132 32nd St  
 directions: Room #108 (Genspace)


### PR DESCRIPTION
## Summary
Follow-up to the Genspace hosts fix — checked all entries with \`hosts: DIYbiosphere\` and fixed the whole pattern.

- **2 entries** (both Genspace community projects) had \`hosts: DIYbiosphere\` where the real host is Genspace — fixed to \`hosts: Genspace\` (dropping the broken empty-link \`partners: - '[Genspace]()'\` duplicate).
- **18 entries** had \`hosts: DIYbiosphere\` with no real host relationship at all — these are independent labs, networks, projects, and companies (Bugss, ChiTownBio, Degenics, JOGL, Ginkgo Bioworks, Twist Bioscience, etc.). Removed the bogus \`hosts:\` block entirely, leaving \`partners:\` and everything else untouched (several have real partner data right after the hosts field that had to be preserved).

Not touched: \`ConectorCiencia.md\`, which matched the initial search but is a false positive — its actual \`hosts:\` value is "Conector Ciência" (itself), with a stale leftover comment that just happens to mention "DIYbiosphere." That's a separate, different oddity (self-referencing host) outside this fix's scope.

## Test plan
- [x] YAML-validated all 20 changed files
- [x] Confirmed \`partners:\` data is fully intact on every entry that had it