### PR TITLE
Add manual prev/next controls to homepage carousel

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,6 +81,18 @@ layout: landing
   {% endfor %}
 </div>
 
+<div class="ui center aligned basic segment carousel-controls">
+  <!-- Manual carousel navigation. Handlers already existed in assets/js/carousel.js
+       (customPrevBtn/customNextBtn), but no matching elements existed anywhere for
+       a user to actually click - this was previously autoplay-only. -->
+  <button class="ui circular icon button customPrevBtn" aria-label="Previous slide">
+    <i class="fas fa-chevron-left icon"></i>
+  </button>
+  <button class="ui circular icon button customNextBtn" aria-label="Next slide">
+    <i class="fas fa-chevron-right icon"></i>
+  </button>
+</div>
+
 <div class="ui grid">
 
   <div class="center aligned row xo padding top fourfold">


### PR DESCRIPTION
## Summary
The carousel only auto-rotates (7s timer) — there was no way to manually navigate. Turns out this was half-built: \`assets/js/carousel.js\` already has click handlers wired up (\`.customPrevBtn\`/\`.customNextBtn\` triggering Owl Carousel's \`prev.owl.carousel\`/\`next.owl.carousel\`), but no elements with those classes existed anywhere in the HTML — so the JS had nothing to attach to.

Added two circular icon buttons directly below the carousel that hook into the existing JS as-is. No JS changes needed.

## Test plan
- [x] Confirmed the class names (\`customPrevBtn\`/\`customNextBtn\`) match exactly what \`carousel.js\` already listens for
- [x] Confirmed \`fa-chevron-left\`/\`fa-chevron-right\` exist in the vendored FontAwesome bundle before using them
- [ ] Deploy preview click-through (I can't click things myself — please confirm the buttons actually advance/rewind the carousel before merging)