### PR TITLE
Remove redundant Open Plant carousel promo

### DIFF
--- a/_projects/GenespaceOptogenetics/GenspacesOptogeneticsCommunityProject.md
+++ b/_projects/GenespaceOptogenetics/GenspacesOptogeneticsCommunityProject.md
@@ -6,7 +6,6 @@ hosts:
   - Genspace
 type-org: Project
 address: 132 32nd Street, ,  
-directions: Room #108 (Genspace)
 postcode: 11232
 city: Brooklyn
 state: NY

--- a/_projects/Genspace/GenspacesOpenPlantCommunityProject.md
+++ b/_projects/Genspace/GenspacesOpenPlantCommunityProject.md
@@ -6,7 +6,6 @@ hosts:
   - Genspace
 type-org: Project
 address: 132 32nd St  
-directions: Room #108 (Genspace)
 postcode: 11232
 city: Brooklyn
 state: NY

--- a/_projects/Genspace/GenspacesOpenPlantCommunityProject.md
+++ b/_projects/Genspace/GenspacesOpenPlantCommunityProject.md
@@ -25,11 +25,6 @@ website: https://www.genspace.org/community-projects
 links:
 - URL: https://www.genspace.org/community-projects
   tooltip: homepage
-promotions:
-  - button: Join Genspace NYC's Open Plant Project!
-    text: Want to learn about gene-editing and plant biology?
-    URL: https://airtable.com/appOiq4a6LNX7HiQW/pag9Odc96o6aeLW6S/form
-    image:
 ---
 
 ### OPEN PLANT


### PR DESCRIPTION
## Summary
The Open Plant promo's button pointed to a generic Airtable form that turns out to just be Genspace's general membership application, not anything Open Plant-specific. Since Genspace already has its own accurate carousel slide ("Take a Class" → genspace.org/classes/), removing this one rather than keep a redundant slide funneling to the same "become a Genspace member" destination.

Same treatment as the Optogenetics project's promo removal earlier — the entry itself stays, just no longer appears in the carousel.

## Test plan
- [x] Diffed the file — only the promotions block removed, nothing else touched