### PR TITLE
Remove Kombucha Genomics from carousel

### DIFF
--- a/_projects/KombuchaGenomics/KombuchaGenomics.md
+++ b/_projects/KombuchaGenomics/KombuchaGenomics.md
@@ -12,10 +12,6 @@ country: United States
 _geoloc:
   lat: 37.835233
   lng: -122.264195
-promotions:
-  - button: Join List
-    text: Get notified about the next meeting.
-    URL: http://tinyurl.com/kombuchamailinglist
 mailing-list: https://groups.google.com/forum/#!forum/kombuchagenomics
 tags:
   - metagenomics


### PR DESCRIPTION
## Summary
Removes the \`promotions:\` block from the Kombucha Genomics entry — redundant with BioArtBot's carousel slide (also Counter Culture Labs-hosted, already links to the same Meetup group), and the mailing list itself has had no real activity since 2024.

Entry stays as-is, just no longer appears in the homepage carousel.

## Test plan
- [x] Diffed the file — only the promotions block removed, nothing else touched