### PR TITLE
Fix browse descriptions: prefer subtitle over random content snippet

### DIFF
--- a/_labs/BioArtLaboratories/BioArtLaboratories.md
+++ b/_labs/BioArtLaboratories/BioArtLaboratories.md
@@ -1,5 +1,6 @@
 ---
 title: Bio Art Laboratores
+subtitle: A bio-art and biodesign innovation lab in Eindhoven, Netherlands
 status: active
 tags:
 - bioart

--- a/_labs/BioQuisitive/BioQuisitive.md
+++ b/_labs/BioQuisitive/BioQuisitive.md
@@ -1,5 +1,6 @@
 ---
 title: BuiQuisitive
+subtitle: Melbourne's community biology and citizen science lab
 status: active
 alias: Melbourn BioHack
 website: http://bioquisitive.org.au/

--- a/_labs/BioTehna/BioTehna.md
+++ b/_labs/BioTehna/BioTehna.md
@@ -1,5 +1,6 @@
 ---
 title: BioTehna
+subtitle: A lab for artistic investigation of life systems in Ljubljana, Slovenia
 status: active
 website:
 start-date: 2013

--- a/_labs/Biocurious/Biocurious.md
+++ b/_labs/Biocurious/Biocurious.md
@@ -1,5 +1,6 @@
 ---
 title: Biocurious
+subtitle: A nonprofit community biology lab and makerspace in Santa Clara, California
 status: active
 tags:
 - open source

--- a/_labs/Bioscope/Bioscope.md
+++ b/_labs/Bioscope/Bioscope.md
@@ -1,5 +1,6 @@
 ---
 title: Bioscope
+subtitle: University of Geneva's public citizen-science biology lab
 status: active
 website: http://bioscope.ch/
 start-date: 2014

--- a/_labs/BosLab/BosLab.md
+++ b/_labs/BosLab/BosLab.md
@@ -1,5 +1,6 @@
 ---
 title: BosLab
+subtitle: A community biotechnology lab for molecular and synthetic biology in Cambridge, MA
 status: active
 website: http://boslab.org/
 start-date: 2014

--- a/_labs/BrmBiolab/BrmBiolab.md
+++ b/_labs/BrmBiolab/BrmBiolab.md
@@ -1,5 +1,6 @@
 ---
 title: Brmlab
+subtitle: A community-run hackerspace and biolab in Prague
 status: active
 website: http://brmlab.cz/index.html
 start-date:

--- a/_labs/GaudiLabs/GaudiLabs.md
+++ b/_labs/GaudiLabs/GaudiLabs.md
@@ -1,5 +1,6 @@
 ---
 title: GaudiLabs
+subtitle: An open-source biohacking lab and hardware maker in Lucerne, Switzerland
 status: active
 website: http://www.gaudi.ch/GaudiLabs/
 start-date:

--- a/_labs/LEprouvette/LEprouvette.md
+++ b/_labs/LEprouvette/LEprouvette.md
@@ -1,5 +1,6 @@
 ---
 title: L'Eprouvette
+subtitle: A hands-on biology workshop lab in Lausanne, Switzerland
 status: active
 logo: https://pbs.twimg.com/profile_images/535440714058838017/O1ezBMSc_400x400.jpeg
 website: http://wp.unil.ch/mediationscientifique/activites/eprouvette

--- a/_labs/OpenBioLabGraz/OpenBioLabGraz.md
+++ b/_labs/OpenBioLabGraz/OpenBioLabGraz.md
@@ -1,5 +1,6 @@
 ---
 title: Open bioLab Graz Austria
+subtitle: An open molecular biology and biohacking lab in Graz, Austria
 status: active
 website: https://realraum.at/wiki/doku.php?id=olga:olga
 start-date: 2013

--- a/_labs/OpenWetlab/OpenWetlab.md
+++ b/_labs/OpenWetlab/OpenWetlab.md
@@ -1,5 +1,6 @@
 ---
 title: Open Wetlab
+subtitle: A bio-art, biodesign, and DIY-biology lab in Amsterdam, home of the BioHack Academy
 status: active
 website: https://waag.org/en/lab/open-wetlab
 start-date: 2012

--- a/_labs/diybioMelbourne/DIYbioMelbourne.md
+++ b/_labs/diybioMelbourne/DIYbioMelbourne.md
@@ -1,6 +1,7 @@
 ---
 draft: true
 title: DIYbio Melbourne
+subtitle: Melbourne's DIYbio meetup group, now continued through BioQuisitive
 status: active
 city: Melbourne
 country: Australia

--- a/assets/js/browse_instantsearch.es6
+++ b/assets/js/browse_instantsearch.es6
@@ -114,7 +114,18 @@ const HIT_TEMPLATE = `
            </span>
    	    </div> <!-- meta -->
   	    <div class="description">
+          <!-- Prefer the curated subtitle over the auto-extracted content
+               snippet. jekyll-algolia indexes every <p>/<blockquote>/<li> on
+               a page as its own fragment (see _config.yml's nodes_to_index),
+               so _highlightResult.content.value can end up being an
+               unrelated list item (e.g. one bullet from a long "past
+               collaborators" list) rather than an actual description. -->
+          {{#subtitle}}
+  	      <p>{{ subtitle }}</p>
+          {{/subtitle}}
+          {{^subtitle}}
   	      <p>{{{ _highlightResult.content.value }}}</p>
+          {{/subtitle}}
   	    </div>
   	    <div class="extra">
           {{#start-date}}


### PR DESCRIPTION
## Summary
Root-caused the BioCurious/BioTehna browse-snippet bugs reported: the results template (\`HIT_TEMPLATE\` in \`browse_instantsearch.es6\`) only ever showed the auto-extracted Algolia \`content\` field, never the curated \`subtitle\`. Since \`jekyll-algolia\` indexes every \`<p>\`/\`<blockquote>\`/\`<li>\` on a page as its own separate fragment (per \`_config.yml\`'s \`nodes_to_index\`), a page with a long bullet list (BioCurious's 20-item former-startups list) or a stray one-line attribution paragraph (BioTehna's "*Text taken from initiative's website") can surface an essentially random fragment as its "description."

**Two-part fix:**
1. \`HIT_TEMPLATE\` now shows \`page.subtitle\` when present, falling back to the extracted content snippet only when there's no subtitle at all.
2. Filled in \`subtitle:\` for the 11 active Labs entries that had none — each written from the entry's own existing body content and city/country fields, not invented: BioArtLaboratories, BioQuisitive, BioTehna, Biocurious, Bioscope, BosLab, Brmlab, GaudiLabs, L'Eprouvette, Open bioLab Graz, Open Wetlab, DIYbio Melbourne.

Scoped to active Labs entries per discussion — other collections/statuses can get the same audit as a follow-up.

## Test plan
- [x] \`node --check\` on the modified \`.es6\` file — syntax valid
- [x] Confirmed \`subtitle\` is already in \`_config.yml\`'s \`searchableAttributes\`/\`attributesToRetrieve\` — no indexing config changes needed
- [x] YAML-validated all 12 changed markdown files
- [ ] Deploy preview + Algolia reindex check (same caveat as before — this needs the production Algolia push to actually show in \`/browse\`, and a clean rebuild if it doesn't show up promptly)