### PR TITLE
Convert Code of Ethics into a DIYbio.org project entry

### DIFF
--- a/_includes/nav/about.html
+++ b/_includes/nav/about.html
@@ -1,6 +1,5 @@
 <a class="item" href="/about/diybiosphere-project"><i class="far fa-info fa-fw icon"></i>DIYbiosphere</a>
 <a class="item" href="/about/diybio-org"><i class="far fa-university fa-fw icon"></i>DIYbio.org</a>
 <a class="item" href="/about/philosophy"><i class="far fa-compass fa-fw icon"></i>Philosophy</a>
-<a class="item" href="/about/code-of-ethics"><i class="far fa-gavel fa-fw icon"></i>Code of Ethics</a>
 <a class="item" href="/about/community"><i class="far fa-heart fa-fw icon"></i>Our Community</a>
 <a class="item" href="/about/contact"><i class="far fa-paper-plane fa-fw icon"></i>Contact</a>

--- a/_projects/CodeOfEthics/CodeOfEthics.md
+++ b/_projects/CodeOfEthics/CodeOfEthics.md
@@ -1,13 +1,22 @@
 ---
-layout: page
-title: Code of Ethics
+title: DIYbio Code of Ethics
+status: active
+subtitle: The movement's founding governance documents, drafted at two 2011 congresses
+start-date: 2011
+type-org: community
+hosts:
+  - DIYbio.org
+tags:
+  - ethics
+  - governance
+  - DIYbio
 ---
 
 In 2011, DIYbio.org organized two congresses — bringing together individuals and delegates from regional DIYbio groups — to draft an aspirational code of ethics for the movement.
 
 In May 2011, delegates from across Europe (Denmark, England, France, Germany, and Ireland) met at the London School of Economics' BIOS Centre. In July 2011, a second congress in San Francisco brought together participants from North American regional groups, including ARC (Houston), BioBridge (San Francisco), BioCurious (Mountain View), BOSSLab (Boston), Genspace (Brooklyn), and LA Biohackers (Los Angeles).
 
-Both congresses produced a draft code. Neither has been formally revised since 2011; they're preserved here as the movement's founding governance documents, adopt, adapt, and remix your own.
+Both congresses produced a draft code. Neither has been formally revised since 2011; they're preserved here as the movement's founding governance documents — adopt, adapt, and remix your own.
 
 ## North American Congress (July 2011)
 

--- a/_references.md
+++ b/_references.md
@@ -25,7 +25,7 @@
 [code of conduct]: /about/code-of-conduct "Our code of conduct"
 [about diybio.org]: /about/diybio-org "About DIYbio.org, the nonprofit behind DIYbiosphere"
 [diybiosphere project page]: /about/diybiosphere-project "About the DIYbiosphere project, including its origin story"
-[code of ethics]: /about/code-of-ethics "DIYbio.org's 2011 codes of ethics"
+[code of ethics]: /projects/codeofethics "DIYbio.org's 2011 codes of ethics"
 [ask a biosafety expert]: /projects/askabiosafetyexpert "DIYbio.org's volunteer biosafety Q&A program (inactive)"
 [support us]: /about/support-us "Ways to support DIYbiosphere and DIYbio.org"
 


### PR DESCRIPTION
## Summary
- Moves the 2011 Code of Ethics from a static About page (`about/code-of-ethics.md`) into a `_projects/` entry (`_projects/CodeOfEthics/`), mirroring the Ask a Biosafety Expert treatment
- Removes the Code of Ethics link from the top About nav — like the biosafety program, it's discoverable via the directory instead
- Repoints the `[code of ethics]` reference-style link to the new `/projects/codeofethics/` URL

## Test plan
- [x] Validated new entry's YAML front matter parses
- [x] Grepped repo for remaining references to the old `/about/code-of-ethics` path — none found
- [x] Confirmed `about/diybio-org.md`'s "[Code of Ethics] page" link resolves correctly via the updated `_references.md` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)