### PR TITLE
Simplify Our Community page, move Gabriela Sanchez to project history

### DIFF
--- a/about/community.md
+++ b/about/community.md
@@ -3,22 +3,20 @@ layout: page
 title: Our Community
 ---
 
-As an open source project, anyone can freely contribute to DIYbiosphere! Only a GitHub account ([sign up]) is necessary. Users who join the [DIYbiosphere organization] are actively involved in contributing and developing the project. The organization is divided into several **teams** with specific roles:
+As an open source project, anyone can freely contribute to DIYbiosphere! Only a GitHub account ([sign up]) is necessary. Users who join the [DIYbiosphere organization] are actively involved in contributing and developing the project. There's no formal hierarchy — active contributors currently include:
 
-- **Board of Directors:** oversee the general direction and development of the project. They also have _admin_ and _owner_ control over the sphere repository and the DIYbiosphere organization respectively.
-  - Jason Bobe: Chief Executive Officer - @JasonBobe
-  - Gabriela A. Sanchez: Chief Project Officer - @sabgaby
-- **Core Developers:** coordinate the software and the content of the entries as well as their design. They have _admin_ access to the sphere respository
-  - Mac Cowell: Chief Technical Officer - @100ideas
-- **Editors:** are in charge of curating entries and their content
-- **Managers:** are all users who are in charge of one or many entries
+- Jason Bobe - @jasonbobe
+- Mac Cowell - @100ideas
+- @danwchan
+
+DIYbiosphere's original vision is credited to Gabriela A. Sanchez, who is no longer involved in the project day-to-day. Read more on the [diybiosphere project page].
 
 ## How to join
 Everyone contributes the same way: [add] or [edit] entries in your own fork and submit a pull request. A maintainer reviews it, and merges once it's ready.
 
-If you're interested in a more involved role on one of the teams above, submit a [new issue] and let us know.
+If you're interested in a more involved role, submit a [new issue] and let us know.
 
 ## Partners
 The project is developed in partnership with the [DIYbio.org](https://diybio.org/) network.
 
-If you would like to become a partner, please contact @sabgaby or @JasonBobe.
+If you would like to become a partner, please contact @jasonbobe.


### PR DESCRIPTION
## Summary
- @sabgaby is no longer involved in the project day-to-day; removes her from the active-contributors list and instead points to the [diybiosphere project page](https://sphere.diybio.org/about/diybiosphere-project/), which already credits her with the project's original vision
- Removes the formal Board of Directors / Core Developers / Editors / Managers hierarchy, which doesn't reflect how the project actually operates — there's no formal hierarchy
- Lists current active contributors flatly: @jasonbobe, @100ideas, @danwchan
- Updates the partner-contact line to just @jasonbobe

## Test plan
- [x] Confirmed `[diybiosphere project page]` reference resolves in `_references.md`
- [x] Confirmed `[DIYbiosphere organization]`, `[sign up]`, `[add]`, `[edit]`, `[new issue]` references all still resolve unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)