### PR TITLE
Add homepage carousel promotion for SoundBio Lab

### DIFF
--- a/_labs/SoundBioLab/SoundBioLab.md
+++ b/_labs/SoundBioLab/SoundBioLab.md
@@ -3,6 +3,11 @@ title: SoundBio Lab
 status: active
 subtitle: Seattle's Biology Makerspace
 website: https://sound.bio/
+promotions:
+  - button: Take a Class
+    text: SoundBio Lab is Seattle's biology makerspace — hands-on STEAM workshops and open lab access for ages 12 through adult, right in the University District.
+    URL: https://www.sound.bio/workshops
+    image: https://images.squarespace-cdn.com/content/v1/5864b03f44024334881622a8/cafb6662-e450-4cce-811f-0729f2180eac/Strawberry+DNA+Extraction+Workshop+at+SoundBio+Lab.webp
 start-date: 2016
 type-org: community
 address: 1100 Northeast 47th Street


### PR DESCRIPTION
## Summary
- SoundBio Lab was invited to submit their own carousel promotion but hasn't yet, so drafting one on their behalf
- Text is drawn from SoundBio's own site copy (workshops, open lab access, ages 12–adult)
- Image is a real photo from sound.bio (a strawberry DNA extraction workshop), CTA links to their workshops/event calendar page
- Follows the same `promotions:` block format used by Genspace, BUGSS, Hackuarium, etc.

## Test plan
- [x] Validated YAML front matter parses
- [x] Confirmed the promo image URL resolves (HTTP 200, image/webp)
- [x] Confirmed the carousel template (`index.html`) picks up any entry with `promotions:` + `promotion.image` automatically — no other file changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)