### PR TITLE
Pin SoundBio Lab's carousel slide right after the intro slide

### DIFF
--- a/_includes/carousel-slide.html
+++ b/_includes/carousel-slide.html
@@ -1,0 +1,45 @@
+<div class="ui image">
+ <div class="ui active inverted dimmer">
+   <div class="content">
+     <div class="center">
+       <div class="ui basic blurring segment">
+         <a href="{{ include.entry.url }}">
+           <div class="ui header promotion">
+             <div class="ui inverted header">
+               <h1 class="ui big inverted header">{{ include.entry.title }}</h1>
+               <h3 class="ui medium inverted header">
+                 {{include.entry.collection | capitalize | append: '%' | remove: 's%' }}
+                   {% if include.entry.hostsExist %}
+                    {% if include.entry.project %}
+                    by
+                    {% else %}
+                    at
+                    {% endif %}
+                    {{include.entry.hostsSentence}}
+                   {% endif %}
+                   {% if include.entry.city %}
+                    in {{include.entry.city}},
+                   {% else %}
+                     {% if include.entry.country %}
+                      in
+                     {% endif %}
+                   {% endif %}
+                   {% if include.entry.country %}
+                    {{include.entry.country}}
+                   {% endif %}
+               </h3>
+             </div>
+            </div>
+         </a>
+         <h3 class="ui big inverted header">{{include.promotion.text | markdownify | replace: '<p>', '' | replace: '</p>', ''}}</h3>
+         <a href="{{ include.promotion.URL }}"><button class="ui large blue button">{{include.promotion.button | markdownify }}</button></a>
+      </div>
+     </div>
+   </div>
+ </div>
+ {% if include.promotion.image %}
+  <img class="ui image owl-img" src="{{ include.promotion.image }}">
+ {% else %}
+  <img class="ui image owl-img" src="{{ include.entry.header }}">
+ {% endif %}
+</div>

--- a/_labs/SoundBioLab/SoundBioLab.md
+++ b/_labs/SoundBioLab/SoundBioLab.md
@@ -8,6 +8,7 @@ promotions:
     text: SoundBio Lab is Seattle's biology makerspace — hands-on STEAM workshops and open lab access for ages 12 through adult, right in the University District.
     URL: https://www.sound.bio/workshops
     image: https://images.squarespace-cdn.com/content/v1/5864b03f44024334881622a8/cafb6662-e450-4cce-811f-0729f2180eac/Strawberry+DNA+Extraction+Workshop+at+SoundBio+Lab.webp
+    pinned: true
 start-date: 2016
 type-org: community
 address: 1100 Northeast 47th Street

--- a/index.html
+++ b/index.html
@@ -23,58 +23,32 @@ layout: landing
     <img class="ui image owl-img" src="/projects/diybiosphere/header.jpg">
   </div>
 
+  <!-- Pinned promotions render right after the intro slide, so they're visible without waiting for the carousel to rotate. -->
   {% for files in site.collections %}
     {% assign entries=files.docs %}
      {% for entry in entries %}
       {% if entry.promotions %}
        {% for promotion in entry.promotions %}
         {% if promotion.image or entry.header %}
-          <div class="ui image">
-           <div class="ui active inverted dimmer">
-             <div class="content">
-               <div class="center">
-                 <div class="ui basic blurring segment">
-                   <a href="{{ entry.url }}">
-                     <div class="ui header promotion">
-                       <div class="ui inverted header">
-                         <h1 class="ui big inverted header">{{ entry.title }}</h1>
-                         <h3 class="ui medium inverted header">
-                           {{entry.collection | capitalize | append: '%' | remove: 's%' }}
-                             {% if entry.hostsExist %}
-                              {% if entry.project %}
-                              by
-                              {% else %}
-                              at
-                              {% endif %}
-                              {{entry.hostsSentence}}
-                             {% endif %}
-                             {% if entry.city %}
-                              in {{entry.city}},
-                             {% else %}
-                               {% if entry.country %}
-                                in
-                               {% endif %}
-                             {% endif %}
-                             {% if entry.country %}
-                              {{entry.country}}
-                             {% endif %}
-                         </h3>
-                       </div>
-                      </div>
-                   </a>
-                   <h3 class="ui big inverted header">{{promotion.text | markdownify | replace: '<p>', '' | replace: '</p>', ''}}</h3>
-                   <a href="{{ promotion.URL }}"><button class="ui large blue button">{{promotion.button | markdownify }}</button></a>
-                </div>
-               </div>
-             </div>
-           </div>
-           {% if promotion.image %}
-            <img class="ui image owl-img" src="{{ promotion.image }}">
-           {% else %}
-            <img class="ui image owl-img" src="{{ entry.header }}">
-           {% endif %}
-         </div>
+         {% if promotion.pinned %}
+          {% include carousel-slide.html entry=entry promotion=promotion %}
          {% endif %}
+        {% endif %}
+      {% endfor %}
+     {% endif %}
+    {% endfor %}
+  {% endfor %}
+
+  {% for files in site.collections %}
+    {% assign entries=files.docs %}
+     {% for entry in entries %}
+      {% if entry.promotions %}
+       {% for promotion in entry.promotions %}
+        {% if promotion.image or entry.header %}
+         {% unless promotion.pinned %}
+          {% include carousel-slide.html entry=entry promotion=promotion %}
+         {% endunless %}
+        {% endif %}
       {% endfor %}
      {% endif %}
     {% endfor %}


### PR DESCRIPTION
## Summary
- Adds a `pinned: true` flag on a `promotions:` entry to hoist that slide to right after the static DIYbiosphere intro slide, so it's visible without waiting for the carousel to auto-rotate through everything else
- Set `pinned: true` on SoundBio Lab's promotion so Roslyn sees it immediately on load
- Extracted the slide markup into `_includes/carousel-slide.html` so the pinned pass and the general pass don't duplicate ~40 lines of near-identical HTML

## Test plan
- [x] Validated YAML front matter parses
- [x] Manually reviewed Liquid syntax (no parens in `{% if %}` conditions — not supported by the Liquid gem)
- [x] Netlify deploy preview will build this PR — will visually confirm SoundBio renders as slide 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)