### PR TITLE
Move carousel promo from BioArtBot to Counter Culture Labs

### DIFF
--- a/_labs/CounterCultureLabs/CounterCultureLabs.md
+++ b/_labs/CounterCultureLabs/CounterCultureLabs.md
@@ -3,6 +3,11 @@ title: Counter Culture Labs
 status: active
 subtitle: Your Biohacking and Citizen Science Lab in Oakland
 website: http://counterculturelabs.org/
+promotions:
+  - button: Visit Counter Culture Labs
+    text: A community hackerspace for DIY biology and citizen science in Oakland — come tinker, build, and learn with us.
+    URL: https://counterculturelabs.org/
+    image: https://counterculturelabs.org/uploads/8/3/9/8/83988754/marc-in-lab-1024x576_orig.jpg
 start-date: 2013
 hosts: "[Omni Commons](https://omnicommons.org)"
 type-org: community
@@ -16,7 +21,6 @@ _geoloc:
   lat: 37.835233
   lng: -122.264195
 email: info@counterculturelabs.org
-wiki: https://counterculturelabs.org/wiki/Counter_Culture_Labs
 meetup: http://www.meetup.com/Counter-Culture-Labs/
 twitter: https://twitter.com/countrcultrlabs
 facebook: https://www.facebook.com/CounterCultureLabs
@@ -28,7 +32,3 @@ tags:
 
 
 We are Counter Culture Labs, a community of scientists, tinkerers, biotech professionals, hackers, and citizen scientists who have banded together to create an open community lab — a hackerspace for DIY biology and citizen science. Help us build a space for creative exploration and discovery: a place to innovate, learn, work on fun projects, and tinker with biology and other sciences. Help us build YOUR lab!
-
-
-
-\*Text taken from initiative's website

--- a/_projects/BioArtBot/BioArtBot.md
+++ b/_projects/BioArtBot/BioArtBot.md
@@ -4,8 +4,8 @@ title: BioArtBot
 status: unknown
 subtitle: Make BioArt with Robots!
 start-date: 2019
-partners:
-  - '[Counter Culture Labs]()'
+hosts:
+  - Counter Culture Labs
 type-org: Project
 address: 4799 Shattuck Ave
 directions: Enter and walk all the way through the door, then turn right to get to Counter Culture Labs
@@ -29,10 +29,6 @@ trello: https://trello.com/b/FKrqcKTU/cll-liquid-handling-robot
 links:
 - URL: http://www.bioartbot.org/
   tooltip: homepage
-promotions:
-  - button: Join us!
-    text: We meet once a week to talk about how to make BioArtBot even better!
-    URL: https://www.meetup.com/Counter-Culture-Labs/
 ---
 
 BioArtBot is a project run out of Counter Culture Labs, a community science lab in Oakland, California. Our goal is to help more people do - and have fun with - science!


### PR DESCRIPTION
## Summary
- BioArtBot's carousel slide showed its own header image, but the button/text/URL were entirely about Counter Culture Labs' generic weekly meetup — no mention of BioArtBot itself. Removed that mismatched promotion.
- Gave Counter Culture Labs its own carousel promo instead, using a real lab photo from counterculturelabs.org (`marc-in-lab`, 1024×576) and CTA linking to their homepage.

### Also fixed while in these files
- BioArtBot's `partners:` field was an empty-URL markdown link (`[Counter Culture Labs]()`, dead href) — changed to a proper `hosts: - Counter Culture Labs` reference, matching the convention used elsewhere on the site
- Counter Culture Labs' `wiki:` link was dead (404) — removed
- Removed a leftover "*Text taken from initiative's website" line in Counter Culture Labs' body copy

## Test plan
- [x] Validated both files' YAML front matter parses
- [x] Confirmed the new promo image URL resolves (HTTP 200, image/jpeg)
- [x] Confirmed `page.wiki` is only used in an `{% if %}`-guarded icon include, safe to remove
- [x] BioArtBot no longer has a `promotions:` block, so the carousel loop's `{% if entry.promotions %}` guard skips it entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)