### PR TITLE
Fix stored XSS via unescaped Algolia highlight results

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,7 +15,9 @@
         algolia: {
           appId: '{{ site.algolia.application_id }}',
           indexName: '{{ site.algolia.index_name }}',
-          apiKey: '{{ site.algolia.search_only_api_key }}'
+          apiKey: '{{ site.algolia.search_only_api_key }}',
+          highlightPreTag: {{ site.algolia.highlightPreTag | jsonify }},
+          highlightPostTag: {{ site.algolia.highlightPostTag | jsonify }}
         }
       };
     </script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,8 +16,8 @@
           appId: '{{ site.algolia.application_id }}',
           indexName: '{{ site.algolia.index_name }}',
           apiKey: '{{ site.algolia.search_only_api_key }}',
-          highlightPreTag: {{ site.algolia.highlightPreTag | jsonify }},
-          highlightPostTag: {{ site.algolia.highlightPostTag | jsonify }}
+          highlightPreTag: {{ site.algolia.settings.highlightPreTag | jsonify }},
+          highlightPostTag: {{ site.algolia.settings.highlightPostTag | jsonify }}
         }
       };
     </script>

--- a/assets/js/browse_instantsearch.es6
+++ b/assets/js/browse_instantsearch.es6
@@ -32,6 +32,59 @@ function withStatusBadge(item) {
   return item;
 }
 
+// Algolia's _highlightResult reflects entry content verbatim (title, city,
+// tags, etc. - all contributor-supplied via PR) with only its
+// highlightPreTag/highlightPostTag markers inserted around matches. Algolia
+// does NOT HTML-escape that content for us - see
+// https://github.com/algolia/vue-instantsearch/pull/783 for the same class
+// of bug in Algolia's own official library. The HIT_TEMPLATE/TABLE_TEMPLATE
+// below render these fields with triple-mustache (unescaped) so the
+// highlight markup renders as real HTML, so we have to sanitize here: escape
+// the whole string, then restore only the one known tag pair Algolia can
+// legitimately produce.
+function escapeHtml(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+const HIGHLIGHT_PRE = (window.site.algolia.highlightPreTag) || '<em>';
+const HIGHLIGHT_POST = (window.site.algolia.highlightPostTag) || '</em>';
+const ESCAPED_HIGHLIGHT_PRE = escapeHtml(HIGHLIGHT_PRE);
+const ESCAPED_HIGHLIGHT_POST = escapeHtml(HIGHLIGHT_POST);
+
+function safeHighlight(value) {
+  if (typeof value !== 'string') return value;
+  return escapeHtml(value)
+    .split(ESCAPED_HIGHLIGHT_PRE).join(HIGHLIGHT_PRE)
+    .split(ESCAPED_HIGHLIGHT_POST).join(HIGHLIGHT_POST);
+}
+
+// Walks an Algolia _highlightResult subtree (objects and arrays alike, since
+// highlighted array attributes like `tags` come back as arrays of
+// {value, matchLevel} objects) and sanitizes every `.value` leaf in place.
+function sanitizeHighlightResult(node) {
+  if (Array.isArray(node)) {
+    node.forEach(sanitizeHighlightResult);
+  } else if (node && typeof node === 'object') {
+    Object.keys(node).forEach((key) => {
+      if (key === 'value' && typeof node.value === 'string') {
+        node.value = safeHighlight(node.value);
+      } else {
+        sanitizeHighlightResult(node[key]);
+      }
+    });
+  }
+}
+
+function withSanitizedHighlights(item) {
+  if (item._highlightResult) sanitizeHighlightResult(item._highlightResult);
+  return item;
+}
+
 search.addWidget(
   instantsearch.widgets.searchBox({
     container: '#search-box',
@@ -216,7 +269,7 @@ const gridHits = instantsearch.widgets.hits({
       item: HIT_TEMPLATE
     },
     transformData: {
-      item: withStatusBadge
+      item: (item) => withStatusBadge(withSanitizedHighlights(item))
     },
   });
 
@@ -231,7 +284,7 @@ const tableHits = instantsearch.widgets.hits({
 		// hits array to get the same status-badge fields per row.
 		transformData: {
 			allItems: (data) => {
-				data.hits = data.hits.map(withStatusBadge);
+				data.hits = data.hits.map((item) => withStatusBadge(withSanitizedHighlights(item)));
 				return data;
 			}
 		},


### PR DESCRIPTION
## Summary
- `assets/js/browse_instantsearch.es6`'s `HIT_TEMPLATE`/`TABLE_TEMPLATE` render `_highlightResult.*` fields (title, city, state, country, tags, predecessor, successor, hostsSentence, partnersSentence, content) with Hogan's triple-mustache `{{{ }}}` (unescaped) syntax
- Algolia does **not** HTML-escape the underlying indexed content for us — `_highlightResult` reflects the entry's real content verbatim, with only the configured `highlightPreTag`/`highlightPostTag` markers inserted around matched substrings. This is a documented Algolia gotcha (Algolia's own `vue-instantsearch` fixed the same class of bug in [PR #783](https://github.com/algolia/vue-instantsearch/pull/783))
- Since entry content is contributor-supplied via PR, a value that survives review and gets indexed (e.g. in `title`, `tags`, or `predecessor`) would execute as HTML/JS for every visitor whose search or browse happens to surface that record — no special action needed beyond normal site usage
- One of the sinks (`tags[].value`) is rendered directly inside an `href="..."` attribute, so it was also vulnerable to attribute-breakout via an unescaped `"`

## Fix
- Escape the full highlighted string, then restore only the one known tag pair Algolia can legitimately insert (`<span class="search-highlight">...</span>`, sourced live from `_config.yml`'s `algolia.highlightPreTag`/`highlightPostTag` via `window.site.algolia`, so it can't silently drift out of sync with the actual config)
- Applied via a recursive walk over `_highlightResult` so it covers both single-value fields and array fields (`tags`) without hardcoding a field list — any future field is covered automatically
- Wired into both `gridHits` (`transformData.item`) and `tableHits` (`transformData.allItems`)

## Scope note
Deliberately **not** touching the several `| markdownify` fields (carousel promo `text:`, `hosts`/`partners` names, etc.). kramdown's GFM mode already allows raw HTML in every entry's own markdown body by design — that's how several existing entries embed `<img>`/`<svg>` today. Those fields don't cross a trust boundary that isn't already crossed by the site's basic content model; restricting them alone wouldn't meaningfully change the actual attack surface. Sanitizing that would be a separate, bigger policy decision (global kramdown HTML restrictions) with real tradeoffs against legitimate existing content — happy to discuss separately if wanted.

## Test plan
- [x] Standalone Node unit test of the sanitization logic (not committed): legit highlight tag preserved verbatim, malicious `<img onerror=...>`/`<script>` escaped, mixed malicious+legit content handled correctly per-field, attribute-breakout via `"` neutralized, full `_highlightResult` tree walk (single value + array), no-op/no-throw when `_highlightResult` is absent — all passed
- [x] Confirmed `jsonify` Liquid filter correctly escapes the embedded `"` in `highlightPreTag`'s value for safe JS-literal embedding
- [ ] Netlify deploy preview — will confirm search/browse still renders and highlights correctly once it builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)