### PR TITLE
Fix dangling [link]-style references and bare URLs site-wide

### DIFF
--- a/_events/GatheringForOpenScienceHardware/GatheringForOpenScienceHardware.md
+++ b/_events/GatheringForOpenScienceHardware/GatheringForOpenScienceHardware.md
@@ -17,6 +17,6 @@ tags:
 Without hardware, there is no science. Instruments, reagents, computers, and lab equipment are the platforms for producing systematic knowledge. Yet, current supply chains limit access and impede creativity and customization through high mark-ups and proprietary designs. This can be compounded by private hardware licenses and patents. Open Science Hardware (OSH) addresses part of this problem by sharing designs, instructions for building, and protocols.
 
 ## Events
-2019: May 17th is the first Great Lakes Gathering for Open Science Hardware in Toronto, Canada. http://openhardware.science/gatherings/great-lakes-gosh-2019/
+2019: May 17th is the first [Great Lakes Gathering for Open Science Hardware](http://openhardware.science/gatherings/great-lakes-gosh-2019/) in Toronto, Canada.
 
 2018: The event took place in Shenzhen, China Oct 10-13.

--- a/docs/EntryTemplate.md
+++ b/docs/EntryTemplate.md
@@ -15,5 +15,4 @@ tags:
   - #REPLACE_with_more_tags
 ---
 
-Markdown_guide:
-https://guides.github.com/features/mastering-markdown/
+Markdown guide: [guides.github.com/features/mastering-markdown](https://guides.github.com/features/mastering-markdown/)

--- a/docs/basics/design.md
+++ b/docs/basics/design.md
@@ -24,5 +24,5 @@ The logo takes the earth sphere with a magnifying glass on the right bottom corn
 The colors scheme is kept at a minimal, using mainly white, grey, black and blue.
 
 ### Semantic-UI Library
-We use [Semantic-UI][semantic] as the UI framework because it is simple to code.
+We use [Semantic-UI](https://semantic-ui.com/) as the UI framework because it is simple to code.
 The framework has been modified from the default theme. Modifying both the `variables` and `override` documents of the src elements

--- a/docs/basics/software.md
+++ b/docs/basics/software.md
@@ -12,13 +12,13 @@ Mainly, we use _GitHub_ to host the files, _Jekyll_ to build them into a website
 # GitHub
 [GitHub](https://github.com) is a [Git](https://git-scm.com/) hosting service that we use to host the source files (repository) of the project and to keep track of the changes made to them. GitHub offers other useful features:
 
-- User interface: Changes to the repository can be done directly on a web browser. We recommend [Installing] the development environment for a more enjoyable experience. We recommend [Atom](https://atom.io/ ) as a text editor, and [GitHub Desktop] as a Git client.
+- User interface: Changes to the repository can be done directly on a web browser. We recommend installing the development environment for a more enjoyable experience. We recommend [Atom](https://atom.io/ ) as a text editor, and [GitHub Desktop](https://desktop.github.com/) as a Git client.
 - Ticketing: we use GitHub Issues to keep track of bugs, questions, feature requests, and pull requests.
 
-The project's repository is named [_sphere_] and it is owned by the [DIYbiosphere organization].
+The project's repository is named [_sphere_][sphere repository] and it is owned by the [DIYbiosphere organization].
 
 # Jekyll
-[Jekyll](https://jekyllrb.com/) is an open-source static site generator written with Ruby. It uses [liquid language].
+[Jekyll](https://jekyllrb.com/) is an open-source static site generator written with Ruby. It uses the [Liquid templating language](https://shopify.github.io/liquid/).
 
 # Netlify
 [Netlify](https://www.netlify.com/) is a continuous deployment service. Every push to `master` triggers Netlify to build the site with Jekyll, push new/changed entries to the Algolia index, and deploy the result - there's no separate `gh-pages` branch involved. Pull requests also get their own preview build, so you can see your changes rendered before merging.

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -34,7 +34,7 @@ note:
 - include a file named `logo.png` or `logo.jpg` or `logo.svg` in your folder. it will automatically be used on your page. [documentation for logos](docs/guides/writing/#logo)
 - if you add a promotion, upload an image to your folder, then add it to the promotion block with a link pointing to `/<path>/<to></your></folder>/<imagename>.ext`. **do not use an external link pointing to externally hosted content!** [docs](/docs/guides/writing/#promotion-boxes)
 
-**WARNING:** malformed yaml (incorrect syntax, often indentation-related) currently causes the build process to crash, breaking site updates. **Please verify your yaml is valid** before committing it. https://yamlchecker.com is an easy way to validate the syntax.
+**WARNING:** malformed yaml (incorrect syntax, often indentation-related) currently causes the build process to crash, breaking site updates. **Please verify your yaml is valid** before committing it. [yamlchecker.com](https://yamlchecker.com) is an easy way to validate the syntax.
 
 ```yaml
 ---

--- a/docs/introduction/getting-started.md
+++ b/docs/introduction/getting-started.md
@@ -15,7 +15,7 @@ The [Writing Guide] is a good reference material for writing awesome entries.
 Don't forget to review the [Contributing Guide] for best practices.
 
 ## Participate in the development
-Check out our [GitHub Issues]. Submit an issue with a suggestion or report a bug. Help by answering, or voting on issues. Tackle issues yourself and commit changes to the repo!
+Check out our [GitHub Issues][issues]. Submit an issue with a suggestion or report a bug. Help by answering, or voting on issues. Tackle issues yourself and commit changes to the repo!
 
 # Downloading the dataset
 Go to the [sphere repository] and select `Clone or Download`, and then select `Download ZIP`. Only the `.md` files in the collection folders are part of the dataset


### PR DESCRIPTION
Site-wide sweep for the "[link] renders as literal brackets" bug and bare URLs in prose that should be clickable, following up on the SoundBio/BioCurious fixes. See commit message for the full breakdown of what was fixed vs. verified as a non-issue.