### PR TITLE
Link GitHub's contributors graph from Our Community page

### DIFF
--- a/_references.md
+++ b/_references.md
@@ -15,6 +15,7 @@
 [sphere]: http://sphere.diybio.org "DIYbiosphere"
 [DIYbiosphere Organization]: https://github.com/DIYbiosphere "DIYbiosphere GitHub organization"
 [issues]: https://github.com/DIYbiosphere/sphere/issues "Sphere GitHub Issues"
+[contributors]: https://github.com/DIYbiosphere/sphere/graphs/contributors?all=1 "Full list of DIYbiosphere contributors on GitHub"
 [new issue]: https://github.com/DIYbiosphere/sphere/issues/new "Create a new issue"
 
 [development community]: /about/community "About our community"

--- a/about/community.md
+++ b/about/community.md
@@ -9,6 +9,8 @@ As an open source project, anyone can freely contribute to DIYbiosphere! Only a 
 - Mac Cowell - @100ideas
 - @danwchan
 
+See the full [contributors] list on GitHub for everyone who's helped build DIYbiosphere over the years.
+
 DIYbiosphere's original vision is credited to Gabriela A. Sanchez, who is no longer involved in the project day-to-day. Read more on the [diybiosphere project page].
 
 ## How to join


### PR DESCRIPTION
Adds a link to https://github.com/DIYbiosphere/sphere/graphs/contributors?all=1 right after the active-contributors list on /about/community/, so visitors can see the full history of everyone who's contributed.