### PR TITLE
Source the Mapbox access token from a Netlify env var, not git

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -18,6 +18,9 @@
           apiKey: '{{ site.algolia.search_only_api_key }}',
           highlightPreTag: {{ site.algolia.settings.highlightPreTag | jsonify }},
           highlightPostTag: {{ site.algolia.settings.highlightPostTag | jsonify }}
+        },
+        mapbox: {
+          accessToken: {{ site.env.mapbox_access_token | jsonify }}
         }
       };
     </script>

--- a/_plugins/env-variables.rb
+++ b/_plugins/env-variables.rb
@@ -1,0 +1,8 @@
+# Exposes select environment variables (set in Netlify's dashboard, not
+# committed to git) to Liquid as site.env.*, so secrets/tokens don't have to
+# live in _config.yml or a committed asset file.
+
+Jekyll::Hooks.register :site, :after_reset do |site|
+  site.config["env"] ||= {}
+  site.config["env"]["mapbox_access_token"] = ENV["MAPBOX_ACCESS_TOKEN"]
+end

--- a/assets/js/mapbox-gl.js
+++ b/assets/js/mapbox-gl.js
@@ -1,4 +1,4 @@
-mapboxgl.accessToken = 'pk.eyJ1IjoiZGl5YmlvLW1hcC1qcmIiLCJhIjoiY21zMHRyMnlmMDBtazJ4b2s2YWJvcnlqYiJ9.ePKokDrKB_2Knc239hc0Xg';
+mapboxgl.accessToken = window.site.mapbox.accessToken;
 
 var map = new mapboxgl.Map({
     container: 'map',


### PR DESCRIPTION
## Summary
Follows up on #351 — moves the Mapbox access token out of committed source and into a Netlify build environment variable, matching the same `window.site.*` pattern already used for Algolia's config in `_layouts/default.html`.

- New `_plugins/env-variables.rb`: exposes select env vars to Liquid as `site.env.*`
- `_layouts/default.html`: adds `window.site.mapbox.accessToken`, sourced from `site.env.mapbox_access_token`
- `assets/js/mapbox-gl.js`: reads `window.site.mapbox.accessToken` instead of a hardcoded string

## Before merging
1. **Revoke the current token** (the one committed in #351) in the Mapbox dashboard — it touched git history, even briefly, so it should be rotated rather than trusted going forward
2. **Create a fresh token**, URL-restricted to `sphere.diybio.org`
3. **Add it to Netlify**: Site settings → Environment variables → `MAPBOX_ACCESS_TOKEN` → paste the new token value
4. Once that's set, this PR is safe to merge — no further code changes needed for the map to pick it up

## Test plan
- [x] Validated plugin Ruby syntax
- [x] Confirmed `window.site` (and thus `window.site.mapbox`) is defined before `mapbox-gl.js` loads (script order in `_layouts/default.html`)
- [ ] After merge + env var set: confirm the map still renders correctly on sphere.diybio.org with the new token

🤖 Generated with [Claude Code](https://claude.com/claude-code)