### PR TITLE
Fill in missing geolocation for 48 entries

### DIFF
--- a/_events/HOPE/HackersOnPlanetEarth.md
+++ b/_events/HOPE/HackersOnPlanetEarth.md
@@ -7,6 +7,9 @@ start-date: 1994
 type-org: Hackerspace
 city: New York
 country: United States
+_geoloc:
+  lat: 40.7127281
+  lng: -74.0060152
 twitter: https://twitter.com/hopeconf
 facebook: 
 tags:

--- a/_events/Igem/Igem.md
+++ b/_events/Igem/Igem.md
@@ -7,6 +7,9 @@ start-date: 2003
 type-org: non-profit
 city: Cambridge
 country: United States
+_geoloc:
+  lat: 42.3656347
+  lng: -71.1040018
 twitter: https://twitter.com/igem
 facebook: https://www.facebook.com/iGEMFoundation/
 tags:

--- a/_events/NationOfMakersConference/NationOfMakersConference.md
+++ b/_events/NationOfMakersConference/NationOfMakersConference.md
@@ -7,6 +7,9 @@ start-date: June 9-10, 2018
 type-org: Organization 
 city: Santa Fe
 country: United States
+_geoloc:
+  lat: 35.6876096
+  lng: -105.938456
 twitter: https://twitter.com/nationofmakers 
 facebook: https://www.facebook.com/nationofmakers 
 tags:

--- a/_events/NewHarvest/NewHarvest.md
+++ b/_events/NewHarvest/NewHarvest.md
@@ -7,6 +7,9 @@ start-date: 2017
 type-org: Organization
 city: New York
 country: United States
+_geoloc:
+  lat: 40.7127281
+  lng: -74.0060152
 twitter: https://twitter.com/NewHarvestOrg 
 facebook: https://www.facebook.com/newharvestorg 
 tags:

--- a/_events/PoreCamp/PoreCampVancouver.md
+++ b/_events/PoreCamp/PoreCampVancouver.md
@@ -7,6 +7,9 @@ start-date: 2015
 type-org:
 city: Vancouver
 country: Canada
+_geoloc:
+  lat: 49.2608724
+  lng: -123.113952
 twitter:
 facebook:
 tags:

--- a/_events/SynBioBeta/SynBioBeta.md
+++ b/_events/SynBioBeta/SynBioBeta.md
@@ -7,6 +7,9 @@ start-date: October 1-3, 2018
 type-org: Company
 city: San Francisco
 country: United States
+_geoloc:
+  lat: 37.7879363
+  lng: -122.4075201
 twitter: https://twitter.com/SynBioBeta 
 facebook: https://www.facebook.com/SynBioBeta/  
 tags:

--- a/_events/TECNOx30/TECNOx30.md
+++ b/_events/TECNOx30/TECNOx30.md
@@ -7,6 +7,9 @@ start-date: April 16 to 21, 2018
 type-org: Organization
 city: Valparaiso
 country: Chile
+_geoloc:
+  lat: -33.0458456
+  lng: -71.6196749
 twitter: https://twitter.com/TecnoxC 
 facebook: https://www.facebook.com/tecnoxlatam/ 
 tags:

--- a/_incubators/HarlemBiospace/HarlemBiospace.md
+++ b/_incubators/HarlemBiospace/HarlemBiospace.md
@@ -10,6 +10,9 @@ address: 423 W 127th Street
 city: New York City
 state: New York
 country: United States
+_geoloc:
+  lat: 40.8133276
+  lng: -73.9541909
 email: director@harlembiospace.com
 twitter: https://twitter.com/Harlembiospace
 facebook: https://www.facebook.com/Harlembiospace

--- a/_incubators/ToolFoundry/ToolFoundry.md
+++ b/_incubators/ToolFoundry/ToolFoundry.md
@@ -7,6 +7,9 @@ start date: 2019-04-01
 type-org: nonprofit
 city: NYC
 country: United States
+_geoloc:
+  lat: 40.7127281
+  lng: -74.0060152
 twitter: https://twitter.com/Tool_Foundry
 facebook:
 instagram: https://www.instagram.com/tool_foundry/

--- a/_labs/BioBlaze/BioBlaze.md
+++ b/_labs/BioBlaze/BioBlaze.md
@@ -10,6 +10,9 @@ postcode: 60185
 city: West Chicago
 state: Illinois
 country: United States
+_geoloc:
+  lat: 41.8847507
+  lng: -88.2039607
 twitter: 
 facebook: https://www.facebook.com/BioBlazeLab
 meetup: https://www.meetup.com/BioBlaze-Community-Bio-Lab/

--- a/_labs/BioClubTokyo/BioClubTokyo.md
+++ b/_labs/BioClubTokyo/BioClubTokyo.md
@@ -9,6 +9,9 @@ address: Shibuya Scramble Crossing
 city: Tokyo
 state: 
 country: Japan
+_geoloc:
+  lat: 35.6594951
+  lng: 139.7004982
 twitter: 
 facebook:
 meetup: 

--- a/_labs/BioCrea/biocrea.md
+++ b/_labs/BioCrea/biocrea.md
@@ -9,6 +9,9 @@ address: Paseo de la Chopera 14
 postcode: 28045
 city: Madrid
 country: Spain
+_geoloc:
+  lat: 40.3929724
+  lng: -3.6984447
 email: info.m@medialab-matadero.es
 facebook: https://www.facebook.com/BioCrea-Espacio-Abierto-de-Biolog%C3%ADa-Creativa-1949666018486706
 tags:

--- a/_labs/Bionest/Bionest.md
+++ b/_labs/Bionest/Bionest.md
@@ -8,6 +8,9 @@ type-org: company
 address: Av. Real Road of Guanajuato, S/N
 city: Irapuato
 country: Mexico
+_geoloc:
+  lat: 20.6758761
+  lng: -101.3521052
 twitter: 
 facebook: https://www.facebook.com/Agrobioteg/
 tags:

--- a/_labs/JustOneGiantLab/JustOneGiantLab.md
+++ b/_labs/JustOneGiantLab/JustOneGiantLab.md
@@ -8,6 +8,9 @@ type-org: nonprofit
 address: 
 city: 
 country: France
+_geoloc:
+  lat: 46.603354
+  lng: 1.8883335
 twitter: https://twitter.com/justonegiantlab
 facebook: 
 tags:

--- a/_labs/Katalab/Katalab.md
+++ b/_labs/Katalab/Katalab.md
@@ -8,6 +8,9 @@ address: Gaullachergasse 12/18 (registered address; no public space yet)
 postcode: 1160
 city: Vienna
 country: Austria
+_geoloc:
+  lat: 48.2083537
+  lng: 16.3725042
 tags:
   - community lab
   - mycelium

--- a/_labs/TheLAb/TheLAb.md
+++ b/_labs/TheLAb/TheLAb.md
@@ -12,6 +12,9 @@ postcode: 90033
 city: Los Angeles
 state: California
 country: United States
+_geoloc:
+  lat: 34.0609976
+  lng: -118.2085343
 rss: http://www.thel4b.com/?feed=rss2
 twitter: https://twitter.com/labiohackers
 facebook: https://www.facebook.com/TheL4b

--- a/_labs/diybioMelbourne/DIYbioMelbourne.md
+++ b/_labs/diybioMelbourne/DIYbioMelbourne.md
@@ -5,6 +5,9 @@ subtitle: Melbourne's DIYbio meetup group, now continued through BioQuisitive
 status: active
 city: Melbourne
 country: Australia
+_geoloc:
+  lat: -37.8142454
+  lng: 144.9631732
 meetup: https://www.meetup.com/DIYbio-Melbourne/
 Facebook: https://www.facebook.com/groups/BiohackMelb/about
 ---

--- a/_networks/CitizenScienceGlobalPartnership/CitizenScienceGlobalPartnership.md
+++ b/_networks/CitizenScienceGlobalPartnership/CitizenScienceGlobalPartnership.md
@@ -7,6 +7,9 @@ start-date: 2017-12-1
 type-org: Nonprofit
 city: Washington DC
 country: United States
+_geoloc:
+  lat: 38.8950982
+  lng: -77.0363849
 twitter: https://twitter.com/citsciglobal
 facebook: 
 tags: 

--- a/_others/BioLinkDepot/BioLinkDepot.md
+++ b/_others/BioLinkDepot/BioLinkDepot.md
@@ -7,6 +7,9 @@ start-date: 2002
 type-org: Nonprofit
 city: San Francisco
 country: United States
+_geoloc:
+  lat: 37.7879363
+  lng: -122.4075201
 twitter: https://twitter.com/biolinkdepot
 facebook: https://www.facebook.com/biolinkdepot
 tags:

--- a/_projects/BooleanBiotech/BooleanBiotech.md
+++ b/_projects/BooleanBiotech/BooleanBiotech.md
@@ -7,6 +7,9 @@ start-date: 2014
 type-org: Project
 city:
 country: United States
+_geoloc:
+  lat: 39.7837304
+  lng: -100.445882
 twitter: https://twitter.com/btnaughton
 github: https://github.com/hgbrian
 tags:

--- a/_projects/CSAEthics/CSAEthics.md
+++ b/_projects/CSAEthics/CSAEthics.md
@@ -7,6 +7,9 @@ hosts:
   - '[Citizen Science Association](http://www.citizenscience.org)' 
 type-org: community
 country: United States
+_geoloc:
+  lat: 39.7837304
+  lng: -100.445882
 tags:
   - biohacking
   - citizen science

--- a/_projects/InteractiveMyceliumLights/InteractiveMyceliumLights.md
+++ b/_projects/InteractiveMyceliumLights/InteractiveMyceliumLights.md
@@ -7,6 +7,9 @@ start-date: 2019-02-16
 type-org: Education 
 city: Philadelphia
 country: United States
+_geoloc:
+  lat: 39.9527237
+  lng: -75.1635262
 twitter: https://twitter.com/csweeneyartist
 facebook: https://m.facebook.com/christopher.sweeney.7771/
 tags: 

--- a/_startups/AlgiKnit/AlgiKnit.md
+++ b/_startups/AlgiKnit/AlgiKnit.md
@@ -7,6 +7,9 @@ start-date: 2017
 type-org: company
 city: New York
 country: United States
+_geoloc:
+  lat: 40.7127281
+  lng: -74.0060152
 twitter: https://twitter.com/algiknit
 facebook: https://www.facebook.com/algiknit
 tags:

--- a/_startups/Allevi/Allevi.md
+++ b/_startups/Allevi/Allevi.md
@@ -7,6 +7,9 @@ start-date: 2014
 type-org: company
 city: Philadelphia
 country: United States
+_geoloc:
+  lat: 39.9527237
+  lng: -75.1635262
 twitter: https://twitter.com/Allevi3D
 facebook: https://www.facebook.com/allevi3D/
 tags:

--- a/_startups/AmidBiosciences/AmidBiosciences.md
+++ b/_startups/AmidBiosciences/AmidBiosciences.md
@@ -7,6 +7,9 @@ start-date: 2016
 type-org: Company/Start-up
 city: Santa Clara
 country: United States
+_geoloc:
+  lat: 37.2333253
+  lng: -121.6846349
 twitter: https://twitter.com/shopify
 facebook: https://www.facebook.com/shopify
 tags:

--- a/_startups/BentoLab/BentoLab.md
+++ b/_startups/BentoLab/BentoLab.md
@@ -8,6 +8,9 @@ type-org: company
 address: Corner of Keeton's and Collett Road, 3Space, Bermondsey, SE16 4EE
 city: London
 country: United Kingdom
+_geoloc:
+  lat: 51.5074456
+  lng: -0.1277653
 twitter: https://www.twitter.com/theBentoLab
 facebook: https://www.facebook.com/theBentoLab
 tags:

--- a/_startups/BillionToOne/BillionToOne.md
+++ b/_startups/BillionToOne/BillionToOne.md
@@ -7,6 +7,9 @@ start-date:
 type-org: Company
 city: Palo Alto
 country: United States
+_geoloc:
+  lat: 37.4443293
+  lng: -122.1598465
 twitter:
 facebook:
 tags:

--- a/_startups/Biomeme/Biomeme.md
+++ b/_startups/Biomeme/Biomeme.md
@@ -7,6 +7,9 @@ start-date: 2013
 type-org: Company/Start-up
 city: Philadelphia
 country: United States
+_geoloc:
+  lat: 39.9527237
+  lng: -75.1635262
 twitter: https://twitter.com/biomemeinc
 facebook: https://www.facebook.com/Biomeme-Inc-170880129735006/?fref=ts
 tags:

--- a/_startups/CellEleven/CellEleven.md
+++ b/_startups/CellEleven/CellEleven.md
@@ -8,6 +8,9 @@ type-org: Hardware
 city: Philadelphia
 state: Pennsylvania
 country: United States
+_geoloc:
+  lat: 39.9527237
+  lng: -75.1635262
 tags:
   - Hardware
   - Software

--- a/_startups/Chronomed/Chronomed.md
+++ b/_startups/Chronomed/Chronomed.md
@@ -7,6 +7,9 @@ start-date: 2016
 type-org: Company
 city: Amsterdam
 country: Netherlands
+_geoloc:
+  lat: 52.3730796
+  lng: 4.8924534
 twitter:
 facebook:
 tags:

--- a/_startups/ClearGene/ClearGene.md
+++ b/_startups/ClearGene/ClearGene.md
@@ -7,6 +7,9 @@ start-date:
 type-org: Start-up
 city: San Francisco
 country: United States
+_geoloc:
+  lat: 37.7879363
+  lng: -122.4075201
 twitter:
 facebook: 
 tags:

--- a/_startups/Combimmune/Combimmune.md
+++ b/_startups/Combimmune/Combimmune.md
@@ -7,6 +7,9 @@ start-date: 2012
 type-org: Company/Start-up
 city: Palo Alto
 country: United States
+_geoloc:
+  lat: 37.4443293
+  lng: -122.1598465
 twitter:
 facebook: 
 tags:

--- a/_startups/ConectorCiencia/ConectorCiencia.md
+++ b/_startups/ConectorCiencia/ConectorCiencia.md
@@ -17,6 +17,9 @@ directions: Villa
 city: Rio de Janeiro
 state: Rio de Janeiro
 country: Brazil
+_geoloc:
+  lat: -22.9110137
+  lng: -43.2093727
 tags:
   - Microscope
   - Education

--- a/_startups/DigiBio/DigiBio.md
+++ b/_startups/DigiBio/DigiBio.md
@@ -7,6 +7,9 @@ start-date: 2017
 type-org: Company/Start-up
 city: Amsterdam
 country: Netherlands
+_geoloc:
+  lat: 52.3730796
+  lng: 4.8924534
 twitter: https://twitter.com/digi_bio
 facebook: https://www.facebook.com/digi.bio.dmf/
 tags:

--- a/_startups/EcovativeDesign/EcovativeDesign.md
+++ b/_startups/EcovativeDesign/EcovativeDesign.md
@@ -7,6 +7,9 @@ start-date: 2007
 type-org: Company
 city: Green Island
 country: United States
+_geoloc:
+  lat: 42.7444456
+  lng: -73.6914935
 twitter: https://twitter.com/search?q=Ecovative&src=typd
 facebook: https://www.facebook.com/ecovative/?fref=gc&dti=161300983894992&hc_location=ufi
 tags:

--- a/_startups/EligoBioscience/EligoBioscience.md
+++ b/_startups/EligoBioscience/EligoBioscience.md
@@ -7,6 +7,9 @@ start-date: 2014
 type-org: Company
 city: Paris
 country: France
+_geoloc:
+  lat: 48.8588897
+  lng: 2.320041
 twitter: https://twitter.com/eligobio
 facebook: https://www.facebook.com/eligobioscience/
 tags:

--- a/_startups/FoliaWater/FoliaWater.md
+++ b/_startups/FoliaWater/FoliaWater.md
@@ -7,6 +7,9 @@ start-date: 2016
 type-org: Company/Start-up
 city: Oakland
 country: United States
+_geoloc:
+  lat: 37.8044557
+  lng: -122.271356
 twitter: https://twitter.com/foliawater
 facebook: https://www.facebook.com/foliawater
 tags:

--- a/_startups/FoliumBiosciences/FoliumBiosciences.md
+++ b/_startups/FoliumBiosciences/FoliumBiosciences.md
@@ -7,6 +7,9 @@ start-date: 2015
 type-org: Company/Start-up
 city: Colorado Springs
 country: United States
+_geoloc:
+  lat: 38.8339578
+  lng: -104.825348
 twitter: https://twitter.com/foliumbio
 facebook: https://www.facebook.com/foliumbio/
 tags:

--- a/_startups/HyasynthBiologicals/HyasynthBiologicals.md
+++ b/_startups/HyasynthBiologicals/HyasynthBiologicals.md
@@ -7,6 +7,9 @@ start-date: 2014
 type-org: Company/Start-up
 city: Montréal
 country: Canada
+_geoloc:
+  lat: 45.5031824
+  lng: -73.5698065
 twitter: https://twitter.com/hyasynthbio
 facebook: https://www.facebook.com/hyasynthbio
 tags:

--- a/_startups/InnovativeMedicine/InnovativeMedicine.md
+++ b/_startups/InnovativeMedicine/InnovativeMedicine.md
@@ -7,6 +7,9 @@ start-date: 2004
 type-org: Company
 city: New York
 country: United States
+_geoloc:
+  lat: 40.7127281
+  lng: -74.0060152
 twitter: https://twitter.com/InnoMedicine
 facebook: https://www.facebook.com/InnoMedicine
 tags:

--- a/_startups/Kilobaser/Kilobaser.md
+++ b/_startups/Kilobaser/Kilobaser.md
@@ -7,6 +7,9 @@ start-date: 2014
 type-org: Company/Sart-up
 city: Graz
 country: Austria
+_geoloc:
+  lat: 47.0708678
+  lng: 15.4382786
 twitter: https://twitter.com/DNAPrototyper
 facebook: https://www.facebook.com/kilobaser.DNA
 tags:

--- a/_startups/Lederer-Stark-Innovations-GbR/Lederer-Stark Innovations GbR.md
+++ b/_startups/Lederer-Stark-Innovations-GbR/Lederer-Stark Innovations GbR.md
@@ -8,6 +8,9 @@ status: inactive
 type-org: company
 city: Allmersbach im Tal
 country: Germany
+_geoloc:
+  lat: 48.9067926
+  lng: 9.4744882
 email: support@ls-innovations.de
 tags:
   - supplies

--- a/_startups/Microsynbiotix/Microsynbiotix.md
+++ b/_startups/Microsynbiotix/Microsynbiotix.md
@@ -7,6 +7,9 @@ start-date:
 type-org: Start-up
 city: San Diego
 country: United States
+_geoloc:
+  lat: 32.7174202
+  lng: -117.162772
 twitter: https://twitter.com/microsynbiotix
 facebook: https://www.facebook.com/microsynbiotix
 tags:

--- a/_startups/PILI/PILI.md
+++ b/_startups/PILI/PILI.md
@@ -7,6 +7,9 @@ start-date: 2014
 type-org: Company/Start-up
 city: Paris
 country: France
+_geoloc:
+  lat: 48.8588897
+  lng: 2.320041
 twitter: https://twitter.com/_pilibio
 facebook: https://www.facebook.com/pilibio
 tags:

--- a/_startups/ProspectiveResearch/ProspectiveResearch.md
+++ b/_startups/ProspectiveResearch/ProspectiveResearch.md
@@ -7,6 +7,9 @@ start-date:
 type-org: Company/Start-up
 city: Beverly
 country: United States
+_geoloc:
+  lat: 42.5489744
+  lng: -70.8781883
 twitter:
 facebook: 
 tags:

--- a/_startups/Quantgene/Quantgene.md
+++ b/_startups/Quantgene/Quantgene.md
@@ -7,6 +7,9 @@ start-date: 2016
 type-org: Company/Start-up
 city: Berkeley
 country: United States
+_geoloc:
+  lat: 37.8708393
+  lng: -122.272863
 twitter:
 facebook: https://www.facebook.com/quantgene/
 tags:

--- a/_startups/SE3D/SE3D.md
+++ b/_startups/SE3D/SE3D.md
@@ -7,6 +7,9 @@ start-date: 2014
 type-org: Company/Start-up
 city: San Francisco
 country: United States
+_geoloc:
+  lat: 37.7879363
+  lng: -122.4075201
 twitter: https://twitter.com/se3dedu
 facebook: https://www.facebook.com/se3dedu/
 tags:

--- a/_startups/feles/Feles.md
+++ b/_startups/feles/Feles.md
@@ -8,6 +8,9 @@ type-org: Company/Startup
 address: 625 Massachusetts Avenue, 
 city: Boston
 country: United States
+_geoloc:
+  lat: 42.337013
+  lng: -71.07739
 tags:
   - Hardware
   - Biotechnology


### PR DESCRIPTION
## Summary
Only 135 of 192 directory entries had `_geoloc` set, so the homepage map was missing ~30% of the directory — Startups were hit hardest (6 of 32 had coordinates). Geocoded the missing entries using their existing `address`/`city`/`state`/`country` fields via OpenStreetMap's Nominatim (no API key needed), falling back to a less specific query when the full street address didn't resolve.

## What's NOT included
9 entries have no location data at all (online-only programs, documents, wikis with no physical location) — left alone rather than fabricating a location: `AskABiosafetyExpert`, `CodeOfEthics`, `OpenGenX`, `RoninGenetics`, `diyhpluswiki`, `Singularity`, `Reclone`, `GatheringForOpenScienceHardware`, `ibiology`.

2 entries (`BooleanBiotech`, `CSAEthics`) only have a `country` field with no city, so they land on the geographic center of the US — imprecise but reasonable at world-map scale, and accurate to what's actually known about them.

## Test plan
- [x] Validated YAML front matter parses on all 48 changed files
- [x] Spot-checked results for sanity (correct country/region for every entry)
- [x] Manually corrected one result (TECNOx30/Valparaíso) where the unaccented query matched the broader region instead of the city

🤖 Generated with [Claude Code](https://claude.com/claude-code)