### PR TITLE
Add a status-color legend and marker clustering to the homepage map

### DIFF
--- a/assets/js/mapbox-gl.js
+++ b/assets/js/mapbox-gl.js
@@ -20,13 +20,47 @@ var entries = "/assets/data/entries.geojson";
 map.on('style.load', function() {
   map.addSource('entries', {
     type: 'geojson',
-    data: entries
+    data: entries,
+    cluster: true,
+    clusterMaxZoom: 12,
+    clusterRadius: 40
+  });
+
+  // Clustered points (dense areas like the US East Coast / Western Europe
+  // collapse into a single circle, sized by how many entries it represents).
+  map.addLayer({
+    id: 'clusters',
+    type: 'circle',
+    source: 'entries',
+    filter: ['has', 'point_count'],
+    paint: {
+      'circle-color': '#4A90D9',
+      'circle-opacity': 0.75,
+      'circle-radius': ['step', ['get', 'point_count'], 12, 10, 16, 25, 20],
+      'circle-stroke-width': 1,
+      'circle-stroke-color': '#ffffff'
+    }
+  });
+
+  map.addLayer({
+    id: 'cluster-count',
+    type: 'symbol',
+    source: 'entries',
+    filter: ['has', 'point_count'],
+    layout: {
+      'text-field': ['get', 'point_count_abbreviated'],
+      'text-size': 12
+    },
+    paint: {
+      'text-color': '#ffffff'
+    }
   });
 
   map.addLayer({
     id: 'entry',
     type: 'circle',
     source: 'entries',
+    filter: ['!', ['has', 'point_count']],
     paint: {
       // entries.geojson already computes 'color' per entry:
       // 'blue' for active/planned status, 'grey' otherwise
@@ -35,6 +69,27 @@ map.on('style.load', function() {
       'circle-stroke-width': 1,
       'circle-stroke-color': '#ffffff'
     }
+  });
+
+  // Clicking a cluster zooms in until it breaks apart into individual points.
+  map.on('click', 'clusters', function (e) {
+      var features = map.queryRenderedFeatures(e.point, { layers: ['clusters'] });
+      var clusterId = features[0].properties.cluster_id;
+      map.getSource('entries').getClusterExpansionZoom(clusterId, function (err, zoom) {
+        if (err) return;
+        map.easeTo({
+          center: features[0].geometry.coordinates,
+          zoom: zoom
+        });
+      });
+  });
+
+  map.on('mouseenter', 'clusters', function () {
+      map.getCanvas().style.cursor = 'pointer';
+  });
+
+  map.on('mouseleave', 'clusters', function () {
+      map.getCanvas().style.cursor = '';
   });
 
   map.on('click', 'entry', function (e) {

--- a/index.html
+++ b/index.html
@@ -252,8 +252,18 @@ layout: landing
       </div>
       <div class="computer tablet only row">
         <div class="sixteen wide column">
-          <div style="height:700px;">
+          <div style="height:700px; position:relative;">
             <div id="map" style="position:absolute; top:0; bottom:0; width:100%; height:700px;"></div>
+            <div class="ui tiny message" style="position:absolute; bottom:1em; left:1em; z-index:1; padding:0.6em 1em; box-shadow: 0 1px 4px rgba(0,0,0,0.25);">
+              <div style="display:flex; align-items:center; margin-bottom:0.3em;">
+                <span style="display:inline-block; width:10px; height:10px; border-radius:50%; background:#4A90D9; margin-right:0.5em;"></span>
+                Active / planned
+              </div>
+              <div style="display:flex; align-items:center;">
+                <span style="display:inline-block; width:10px; height:10px; border-radius:50%; background:#9B9B9B; margin-right:0.5em;"></span>
+                Inactive / unknown
+              </div>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- **Legend**: small overlay in the map's bottom-left corner explaining the blue (active/planned) vs grey (inactive/unknown) marker colors — previously undocumented anywhere on the page
- **Clustering**: with coverage going from 135 to 183 markers once #396 merges, dense regions (US East Coast, Western Europe) would otherwise show overlapping, hard-to-click dots at low zoom. Mapbox GL JS's built-in GeoJSON clustering groups nearby points into a single numbered circle that expands (zooms in) on click; individual markers keep the existing click-to-popup behavior once zoomed in far enough

## Test plan
- [x] Validated JS syntax
- [ ] Confirm clusters render at low zoom and expand correctly on click on the deploy preview
- [ ] Confirm legend displays correctly and doesn't overlap map controls

🤖 Generated with [Claude Code](https://claude.com/claude-code)