### PR TITLE
Default the map to active-only entries, add a toggle to show all

### DIFF
--- a/assets/js/mapbox-gl.js
+++ b/assets/js/mapbox-gl.js
@@ -13,14 +13,34 @@ var map = new mapboxgl.Map({
     zoom: 1.2,
 });
 
-var entries = "/assets/data/entries.geojson";
+var entriesURL = "/assets/data/entries.geojson";
+var allEntries = null; // populated once fetched; toggled between full/active-only below
+
+function activeOnlyFeatures(featureCollection) {
+  return {
+    type: 'FeatureCollection',
+    features: featureCollection.features.filter(function (f) {
+      return f.properties.status === 'active';
+    })
+  };
+}
 
 // entries.geojson already aggregates every collection (projects, labs,
 // startups, etc.) in one file, so a single source/layer covers all of them.
+// Defaults to active-only (matching /browse's default), with a checkbox to
+// reveal inactive/unknown entries too - see the #show-all-entries handler
+// below, near the bottom of this file.
 map.on('style.load', function() {
+  fetch(entriesURL)
+    .then(function (res) { return res.json(); })
+    .then(function (data) {
+      allEntries = data;
+      map.getSource('entries').setData(activeOnlyFeatures(allEntries));
+    });
+
   map.addSource('entries', {
     type: 'geojson',
-    data: entries,
+    data: { type: 'FeatureCollection', features: [] }, // filled in once fetched, above
     cluster: true,
     clusterMaxZoom: 12,
     clusterRadius: 40
@@ -138,3 +158,13 @@ map.addControl(new mapboxgl.NavigationControl());
 map.addControl(new mapboxgl.AttributionControl({
   compact: true
 }));
+
+// Toggle between active-only (default) and every entry regardless of status.
+var showAllCheckbox = document.getElementById('show-all-entries');
+if (showAllCheckbox) {
+  showAllCheckbox.addEventListener('change', function () {
+    if (!allEntries) return; // not fetched yet
+    var data = showAllCheckbox.checked ? allEntries : activeOnlyFeatures(allEntries);
+    map.getSource('entries').setData(data);
+  });
+}

--- a/index.html
+++ b/index.html
@@ -257,11 +257,17 @@ layout: landing
             <div class="ui tiny message" style="position:absolute; bottom:1em; left:1em; z-index:1; padding:0.6em 1em; box-shadow: 0 1px 4px rgba(0,0,0,0.25);">
               <div style="display:flex; align-items:center; margin-bottom:0.3em;">
                 <span style="display:inline-block; width:10px; height:10px; border-radius:50%; background:#4A90D9; margin-right:0.5em;"></span>
-                Active / planned
+                Active
               </div>
               <div style="display:flex; align-items:center;">
                 <span style="display:inline-block; width:10px; height:10px; border-radius:50%; background:#9B9B9B; margin-right:0.5em;"></span>
                 Inactive / unknown
+              </div>
+              <div style="border-top:1px solid rgba(0,0,0,0.1); margin-top:0.5em; padding-top:0.5em;">
+                <label style="display:flex; align-items:center; cursor:pointer; font-weight:normal;">
+                  <input type="checkbox" id="show-all-entries" style="margin-right:0.5em;">
+                  Show inactive/unknown too
+                </label>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Map now defaults to showing only `status: active` entries, matching `/browse`'s existing default behavior
- Added a "Show inactive/unknown too" checkbox in the legend box to reveal everything — fetches `entries.geojson` once and filters/swaps client-side via `setData()`, no extra network request
- Simplified the legend's "Active / planned" label to just "Active" — nothing currently uses `status: planned` (0 of 192 entries), matching the same simplification already applied to the `/browse` filter hint text

## Test plan
- [x] Validated JS syntax
- [ ] Confirm map loads active-only by default on the deploy preview
- [ ] Confirm checking the box reveals inactive/unknown markers, unchecking reverts

🤖 Generated with [Claude Code](https://claude.com/claude-code)