### PR TITLE
Show entry logos in map popups

### DIFF
--- a/assets/data/entries.geojson
+++ b/assets/data/entries.geojson
@@ -14,6 +14,7 @@ layout:
           "properties": {
             "title": {{ page.title | jsonify }},
             "url": {{ page.url | jsonify }},
+            "logo": {{ page.logo | jsonify }},
             "address": {{ page.address | jsonify }},
             "city": {{ page.city | jsonify }},
             "state": {{ page.state | jsonify }},
@@ -33,6 +34,7 @@ layout:
           "properties": {
             "title": {{ page.title | jsonify }},
             "url": {{ page.url | jsonify }},
+            "logo": {{ page.logo | jsonify }},
             "address": {{ page.address | jsonify }},
             "city": {{ page.city | jsonify }},
             "state": {{ page.state | jsonify }},

--- a/assets/js/mapbox-gl.js
+++ b/assets/js/mapbox-gl.js
@@ -116,6 +116,7 @@ map.on('style.load', function() {
       var coordinates = e.features[0].geometry.coordinates.slice();
       var title = e.features[0].properties.title;
       var url = e.features[0].properties.url;
+      var logo = e.features[0].properties.logo;
       var city = e.features[0].properties.city;
       var country = e.features[0].properties.country;
       var status = e.features[0].properties.status;
@@ -135,9 +136,13 @@ map.on('style.load', function() {
           coordinates[0] += e.lngLat.lng > coordinates[0] ? 360 : -360;
       };
 
+      var logoHtml = (logo && logo !== 'null')
+          ? '<img src="' + logo + '" style="width:40px; height:40px; object-fit:contain; border-radius:4px; margin-right:0.6em; flex-shrink:0;">'
+          : '';
+
       new mapboxgl.Popup()
           .setLngLat(coordinates)
-          .setHTML('<div style="font-family:source code pro;"><div><b><a href="' + url +'">' + title + '</a></b></div><div>' + location + '</div><p class="xo text fairly smaller grey color">' + collectionType + ' with ' + '<em>' + status + '</em>' + ' status' + '</p></div>')
+          .setHTML('<div style="font-family:source code pro; display:flex; align-items:flex-start;">' + logoHtml + '<div><div><b><a href="' + url +'">' + title + '</a></b></div><div>' + location + '</div><p class="xo text fairly smaller grey color">' + collectionType + ' with ' + '<em>' + status + '</em>' + ' status' + '</p></div></div>')
           .addTo(map);
   });
 


### PR DESCRIPTION
## Summary
`entries.geojson` never exposed `page.logo`, so map popups were text-only (title/location/status). Added `logo` to both GeoJSON property blocks (main loop + the special-cased DIYbiosphere feature) and a small 40x40 thumbnail to the popup when an entry has one.

Entries without a logo render exactly as before — no layout change for them, matches the same falsy/`'null'`-string fallback check already used for `city` elsewhere in this file.

## Test plan
- [x] Validated JS syntax
- [ ] Confirm popups show a logo thumbnail for entries that have one, and render unchanged for entries that don't

🤖 Generated with [Claude Code](https://claude.com/claude-code)