### PR TITLE
Add Plasmidsaurus and Zymo Research to the directory

### DIFF
--- a/_others/Plasmidsaurus/Plasmidsaurus.md
+++ b/_others/Plasmidsaurus/Plasmidsaurus.md
@@ -1,0 +1,25 @@
+---
+title: Plasmidsaurus
+status: active
+subtitle: Affordable, no-minimum DNA/RNA sequencing-as-a-service, from a single plasmid to microbiome samples
+start-date: 2021
+type-org: Company
+address: 1850 Millrace Dr, Suite 200
+city: Eugene
+state: Oregon
+country: United States
+_geoloc:
+  lat: 44.0484994
+  lng: -123.0667814
+website: https://plasmidsaurus.com
+tags:
+  - DNA sequencing
+  - RNA sequencing
+  - microbiome
+  - low-cost
+links:
+  - URL: https://plasmidsaurus.com
+    tooltip: homepage
+---
+
+Plasmidsaurus started as a low-cost, overnight Oxford Nanopore-based plasmid sequencing service ($15/plasmid) and has since expanded into RNA-Seq, whole genome sequencing, amplicon sequencing, AAV sequencing, and microbiome/16S sequencing — all accessible with no minimum order size, down to a single sample. That accessibility has made it a popular option for independent researchers, hobbyists, and citizen scientists who don't have institutional core-facility access, not just traditional academic/industry labs.

--- a/_others/ZymoResearch/ZymoResearch.md
+++ b/_others/ZymoResearch/ZymoResearch.md
@@ -1,0 +1,27 @@
+---
+title: Zymo Research
+status: active
+subtitle: Molecular biology tools and sequencing services, including single-sample metatranscriptomics from unprocessed samples like saliva
+start-date: 1994
+type-org: Company
+address: 17062 Murphy Ave
+city: Irvine
+state: California
+country: United States
+_geoloc:
+  lat: 33.6861092
+  lng: -117.8304918
+website: https://www.zymoresearch.com
+tags:
+  - DNA extraction
+  - RNA sequencing
+  - metatranscriptomics
+  - microbiome
+links:
+  - URL: https://www.zymoresearch.com
+    tooltip: homepage
+  - URL: https://www.zymoresearch.com/pages/metatranscriptomic-sequencing-services
+    tooltip: Metatranscriptomic Sequencing Services
+---
+
+Zymo Research makes DNA/RNA sample collection and purification tools (including the widely-used DNA/RNA Shield preservation kits) and offers next-generation sequencing services built on them — microbiome/16S profiling, RNA-Seq, methylation analysis, and metatranscriptomic sequencing. Their metatranscriptomic service is notable for accepting a single unprocessed sample (e.g. saliva) with no need for prior extraction, priced accessibly (around $375 for ~30 million paired-end reads) — useful for individuals investigating RNA viruses or active microbial gene expression, which standard DNA-only sequencing can't capture.


### PR DESCRIPTION
## Summary
Both surfaced via Boolean Biotech's blog as low-cost, no-minimum-sample-size sequencing services citizen scientists actually use:

- **Plasmidsaurus**: overnight Nanopore-based plasmid/RNA/genome/microbiome sequencing, no minimum order size (started as $15 overnight plasmid sequencing, has since expanded)
- **Zymo Research**: DNA/RNA sample collection kits plus NGS services, including single-sample metatranscriptomic sequencing from an unprocessed sample (e.g. saliva) — this is what Brian Naughton used in his oral microbiome self-experiment posts

## Why "Others" and not "Startups"
Both are established service/product companies rather than DIYbio-founded startups — Others is already the precedent for this category (Twist Bioscience, Biorender). If more entries like these accumulate, a dedicated "DIYbio-friendly services" collection might be worth it later, but not for just two entries.

## Test plan
- [x] Validated YAML front matter parses on both
- [x] Confirmed all URLs resolve (homepage + Zymo's specific service page)
- [x] Geocoded both addresses, confirmed via Nominatim

🤖 Generated with [Claude Code](https://claude.com/claude-code)